### PR TITLE
Add equipment requirements support with UI display (Vibe Kanban)

### DIFF
--- a/logic/lib/src/data/items.dart
+++ b/logic/lib/src/data/items.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:equatable/equatable.dart';
 import 'package:logic/src/data/combat.dart' show AttackType;
 import 'package:logic/src/data/melvor_id.dart';
+import 'package:logic/src/data/shop.dart' show ShopRequirement;
 import 'package:logic/src/types/drop.dart';
 import 'package:logic/src/types/equipment_slot.dart';
 import 'package:logic/src/types/inventory.dart';
@@ -190,6 +191,7 @@ class Item extends Equatable {
     this.modifiers = const ModifierDataSet([]),
     this.equipmentStats = EquipmentStats.empty,
     this.attackType,
+    this.equipRequirements = const [],
   });
 
   /// Creates a simple test item with minimal required fields.
@@ -202,6 +204,7 @@ class Item extends Equatable {
     this.compostValue,
     this.harvestBonus,
     this.attackType,
+    this.equipRequirements = const [],
   }) : id = MelvorId('melvorD:${name.replaceAll(' ', '_')}'),
        itemType = 'Item',
        sellsFor = gp,
@@ -270,6 +273,18 @@ class Item extends Equatable {
     final equipmentStatsJson = json['equipmentStats'] as List<dynamic>?;
     final equipmentStats = EquipmentStats.fromJson(equipmentStatsJson);
 
+    // Parse equipment requirements (same format as shop requirements).
+    final equipReqsJson = json['equipRequirements'] as List<dynamic>? ?? [];
+    final equipRequirements = equipReqsJson
+        .map(
+          (e) => ShopRequirement.fromJson(
+            e as Map<String, dynamic>,
+            namespace: namespace,
+          ),
+        )
+        .whereType<ShopRequirement>()
+        .toList();
+
     return Item(
       id: id,
       name: json['name'] as String,
@@ -289,6 +304,7 @@ class Item extends Equatable {
       attackType: json['attackType'] != null
           ? AttackType.fromJson(json['attackType'] as String)
           : null,
+      equipRequirements: equipRequirements,
     );
   }
 
@@ -344,6 +360,10 @@ class Item extends Equatable {
   /// Null for non-weapon items.
   final AttackType? attackType;
 
+  /// Requirements that must be met to equip this item.
+  /// Empty list means no requirements.
+  final List<ShopRequirement> equipRequirements;
+
   /// Whether this item can be consumed for healing.
   bool get isConsumable => healsFor != null;
 
@@ -383,6 +403,7 @@ class Item extends Equatable {
     modifiers,
     equipmentStats,
     attackType,
+    equipRequirements,
   ];
 }
 

--- a/logic/lib/src/state.dart
+++ b/logic/lib/src/state.dart
@@ -1235,11 +1235,22 @@ class GlobalState {
     return copyWith(equipment: equipment.copyWith(selectedFoodSlot: slotIndex));
   }
 
+  /// Returns true if the player meets all requirements to equip the item.
+  bool canEquipGear(Item item) {
+    return item.equipRequirements.every((req) => req.isMet(this));
+  }
+
+  /// Returns the list of equipment requirements not met by the player.
+  /// Returns an empty list if all requirements are met.
+  List<ShopRequirement> unmetEquipRequirements(Item item) {
+    return item.equipRequirements.where((req) => !req.isMet(this)).toList();
+  }
+
   /// Equips a gear item from inventory to a specific equipment slot.
   /// Removes one item from inventory and equips it.
   /// If there was an item in that slot, it's returned to inventory.
-  /// Throws StateError if player doesn't have the item or inventory is full
-  /// when swapping.
+  /// Throws StateError if player doesn't have the item, doesn't meet
+  /// requirements, or inventory is full when swapping.
   GlobalState equipGear(Item item, EquipmentSlot slot) {
     if (!item.isEquippable) {
       throw StateError('Cannot equip ${item.name}: not equippable');
@@ -1249,6 +1260,9 @@ class GlobalState {
         'Cannot equip ${item.name} in $slot slot. '
         'Valid slots: ${item.validSlots}',
       );
+    }
+    if (!canEquipGear(item)) {
+      throw StateError('Cannot equip ${item.name}: requirements not met');
     }
     if (inventory.countOfItem(item) < 1) {
       throw StateError('Cannot equip ${item.name}: not in inventory');

--- a/logic/test/equip_requirements_test.dart
+++ b/logic/test/equip_requirements_test.dart
@@ -1,0 +1,204 @@
+import 'package:logic/logic.dart';
+import 'package:test/test.dart';
+
+import 'test_helper.dart';
+
+void main() {
+  late Item bronzeSword;
+  late Item runeSword;
+
+  setUpAll(() async {
+    await loadTestRegistries();
+    bronzeSword = testItems.byName('Bronze Sword');
+    runeSword = testItems.byName('Rune Sword');
+  });
+
+  group('Item.equipRequirements', () {
+    test('bronze sword requires level 1 Attack', () {
+      expect(bronzeSword.equipRequirements, isNotEmpty);
+      expect(bronzeSword.equipRequirements.length, 1);
+
+      final req = bronzeSword.equipRequirements.first;
+      expect(req, isA<SkillLevelRequirement>());
+
+      final skillReq = req as SkillLevelRequirement;
+      expect(skillReq.skill, Skill.attack);
+      expect(skillReq.level, 1);
+    });
+
+    test('rune sword requires level 40 Attack', () {
+      expect(runeSword.equipRequirements, isNotEmpty);
+
+      final req = runeSword.equipRequirements.first;
+      expect(req, isA<SkillLevelRequirement>());
+
+      final skillReq = req as SkillLevelRequirement;
+      expect(skillReq.skill, Skill.attack);
+      expect(skillReq.level, 40);
+    });
+  });
+
+  group('GlobalState.canEquipGear', () {
+    test('returns true when requirements are met', () {
+      final state = GlobalState.test(
+        testRegistries,
+        // Attack level 1 (default) meets bronze sword requirement
+        skillStates: const {
+          Skill.attack: SkillState(xp: 100, masteryPoolXp: 0),
+        },
+      );
+
+      expect(state.canEquipGear(bronzeSword), isTrue);
+    });
+
+    test('returns true when skill level exceeds requirement', () {
+      final state = GlobalState.test(
+        testRegistries,
+        // Attack level 50 exceeds rune sword's level 40 requirement
+        skillStates: const {
+          Skill.attack: SkillState(xp: 101333, masteryPoolXp: 0),
+        },
+      );
+
+      expect(state.canEquipGear(runeSword), isTrue);
+    });
+
+    test('returns false when skill level is too low', () {
+      final state = GlobalState.test(
+        testRegistries,
+        // Attack level 1 is below rune sword's level 40 requirement
+        skillStates: const {
+          Skill.attack: SkillState(xp: 100, masteryPoolXp: 0),
+        },
+      );
+
+      expect(state.canEquipGear(runeSword), isFalse);
+    });
+
+    test('returns true for items with no requirements', () {
+      // Create an item with no equip requirements
+      final noReqItem = Item.test('No Req Weapon', gp: 100);
+
+      final state = GlobalState.test(testRegistries);
+
+      expect(state.canEquipGear(noReqItem), isTrue);
+    });
+  });
+
+  group('GlobalState.unmetEquipRequirements', () {
+    test('returns empty list when all requirements are met', () {
+      final state = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.attack: SkillState(xp: 101333, masteryPoolXp: 0),
+        },
+      );
+
+      expect(state.unmetEquipRequirements(runeSword), isEmpty);
+    });
+
+    test('returns unmet requirements when skill is too low', () {
+      final state = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.attack: SkillState(xp: 100, masteryPoolXp: 0),
+        },
+      );
+
+      final unmet = state.unmetEquipRequirements(runeSword);
+      expect(unmet, hasLength(1));
+      expect(unmet.first, isA<SkillLevelRequirement>());
+
+      final req = unmet.first as SkillLevelRequirement;
+      expect(req.skill, Skill.attack);
+      expect(req.level, 40);
+    });
+  });
+
+  group('GlobalState.equipGear with requirements', () {
+    test('throws when requirements not met', () {
+      // Create a state with a low attack level and rune sword in inventory
+      var state = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.attack: SkillState(xp: 100, masteryPoolXp: 0),
+        },
+      );
+
+      // Add rune sword to inventory
+      state = state.copyWith(
+        inventory: state.inventory.adding(ItemStack(runeSword, count: 1)),
+      );
+
+      expect(
+        () => state.equipGear(runeSword, EquipmentSlot.weapon),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('requirements not met'),
+          ),
+        ),
+      );
+    });
+
+    test('succeeds when requirements are met', () {
+      // Create a state with sufficient attack level and rune sword in inventory
+      var state = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.attack: SkillState(xp: 101333, masteryPoolXp: 0),
+        },
+      );
+
+      // Add rune sword to inventory
+      state = state.copyWith(
+        inventory: state.inventory.adding(ItemStack(runeSword, count: 1)),
+      );
+
+      final newState = state.equipGear(runeSword, EquipmentSlot.weapon);
+
+      expect(newState.equipment.gearInSlot(EquipmentSlot.weapon), runeSword);
+      expect(newState.inventory.countOfItem(runeSword), 0);
+    });
+  });
+
+  group('Multiple requirements', () {
+    test('items with multiple requirements check all of them', () async {
+      // Find an item with multiple requirements (Slayer Helmet needs Defence
+      // and Slayer at level 30)
+      final slayerHelmet = testItems.byName('Slayer Helmet (Strong)');
+
+      expect(slayerHelmet.equipRequirements.length, greaterThanOrEqualTo(2));
+
+      // XP for level 30 is 13363 (from xp.dart table, index 29)
+      const level30Xp = 13363;
+
+      // State with only Defence at level 30, Slayer at level 1
+      final partialState = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.defence: SkillState(xp: level30Xp, masteryPoolXp: 0),
+          // Slayer level 1 (default or unset)
+        },
+      );
+
+      expect(partialState.canEquipGear(slayerHelmet), isFalse);
+
+      final unmet = partialState.unmetEquipRequirements(slayerHelmet);
+      expect(unmet.length, greaterThanOrEqualTo(1));
+
+      // State with both Defence and Slayer at level 30
+      final fullState = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.defence: SkillState(xp: level30Xp, masteryPoolXp: 0),
+          Skill.slayer: SkillState(xp: level30Xp, masteryPoolXp: 0),
+        },
+      );
+
+      expect(fullState.canEquipGear(slayerHelmet), isTrue);
+      expect(fullState.unmetEquipRequirements(slayerHelmet), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

This PR adds support for `Item.equipRequirements`, allowing items to have skill level requirements that must be met before equipping.

## Changes

### Logic Layer (`logic/`)
- **`items.dart`**: Added `equipRequirements` field to `Item` class, parsed from JSON using the existing `ShopRequirement` format
- **`state.dart`**: Added `canEquipGear()` and `unmetEquipRequirements()` methods to `GlobalState`, and enforced requirements in `equipGear()` (throws `StateError` if not met)
- **`equip_requirements_test.dart`**: Comprehensive test coverage for:
  - Parsing requirements from item data (Bronze Sword level 1, Rune Sword level 40)
  - `canEquipGear()` returns correct values based on skill levels
  - `unmetEquipRequirements()` returns the list of unmet requirements
  - `equipGear()` throws when requirements not met, succeeds when met
  - Multiple requirements (e.g., Slayer Helmet requiring both Defence and Slayer)

### UI Layer (`ui/`)
- **`bank.dart`**: 
  - Added `_EquipRequirementsDisplay` widget showing unmet requirements with skill icons
  - Modified `_EquipSlotButton` to disable when requirements are not met
  - Displays requirements similar to shop requirements UI pattern

## Implementation Details

- Reuses `ShopRequirement` classes since equipment requirements use the same JSON format (`type`, `skillID`, `level`)
- Requirements are checked via `ShopRequirement.isMet(GlobalState)` which evaluates skill levels
- UI shows skill icon and required level for each unmet requirement

---

This PR was written using [Vibe Kanban](https://vibekanban.com)