### PR TITLE
feat: display monster image in combat screen

### DIFF
--- a/ui/lib/src/screens/combat.dart
+++ b/ui/lib/src/screens/combat.dart
@@ -606,6 +606,12 @@ class _MonsterCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            Center(
+              child: action.media != null
+                  ? CachedImage(assetPath: action.media, size: 80)
+                  : const Icon(Icons.bug_report, size: 80),
+            ),
+            const SizedBox(height: 8),
             Row(
               children: [
                 Text(


### PR DESCRIPTION
## Summary
- Show the monster's media image prominently at the top of the monster card during combat
- Makes it easier to identify which creature is being fought

## Test plan
- [ ] Start combat with any monster (e.g., Plant)
- [ ] Verify the monster image appears at the top of the combat card

🤖 Generated with [Claude Code](https://claude.com/claude-code)