### PR TITLE
Add mastery token drop and claim support (Vibe Kanban)

### DIFF
--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -1407,6 +1407,25 @@ bool rollAndCollectDrops(
       }
     }
   }
+
+  // Roll mastery token drop (separate from other drops, not affected by
+  // doubling chance). Mastery tokens drop from non-combat skills only.
+  final masteryTokenDrop = registries.drops.masteryTokenForSkill(action.skill);
+  if (masteryTokenDrop != null) {
+    final unlockedActions = builder.state.unlockedActionsCount(action.skill);
+    final tokenStack = masteryTokenDrop.rollWithContext(
+      registries.items,
+      random,
+      unlockedActions: unlockedActions,
+    );
+    if (tokenStack != null) {
+      final success = builder.addInventory(tokenStack);
+      if (!success) {
+        allItemsAdded = false;
+      }
+    }
+  }
+
   return allItemsAdded;
 }
 

--- a/logic/lib/src/data/actions.dart
+++ b/logic/lib/src/data/actions.dart
@@ -354,12 +354,25 @@ class DropsRegistry {
     return _skillDrops[skill] ?? [];
   }
 
+  /// Returns the mastery token drop for a skill, or null if the skill
+  /// doesn't have mastery tokens (combat skills, Township, Alt. Magic).
+  MasteryTokenDrop? masteryTokenForSkill(Skill skill) {
+    if (!MasteryTokenDrop.skillHasMasteryToken(skill)) {
+      return null;
+    }
+    return MasteryTokenDrop(skill: skill);
+  }
+
   /// Returns all drops that should be processed when a skill action completes.
   /// This combines action-level drops (from the action), skill-level drops,
   /// and global drops into a single list. Includes both simple Drops and
   /// DropTables, which are processed uniformly via Droppable.roll().
   /// Note: Only SkillActions have rewards - CombatActions handle drops
   /// differently.
+  ///
+  /// Mastery token drops are NOT included here because they require context
+  /// (unlocked action count) to roll. They are handled separately in
+  /// rollAndCollectDrops.
   List<Droppable> allDropsForAction(
     SkillAction action,
     RecipeSelection selection,


### PR DESCRIPTION
## Summary

Implements mastery token drops and claiming functionality based on [Melvor Idle's mastery token system](https://wiki.melvoridle.com/w/Mastery_Tokens).

### Changes Made

- **New `MasteryTokenDrop` class** (`logic/lib/src/types/drop.dart`): Implements the dynamic drop rate formula where chance = `unlockedActions / 18500`. More unlocked actions means higher drop rate.

- **Updated `DropsRegistry`** (`logic/lib/src/data/actions.dart`): Added `masteryTokenForSkill()` method to get the mastery token drop for each skill.

- **Integrated with tick processing** (`logic/lib/src/consume_ticks.dart`): Mastery tokens now roll as a separate drop on each skill action completion (not affected by doubling chance).

- **Token claiming methods** (`logic/lib/src/state.dart`): Added `claimMasteryToken()` and `claimAllMasteryTokens()` to consume tokens and add 0.1% of max mastery pool XP per token.

- **Comprehensive tests** (`logic/test/mastery_token_test.dart`): Tests for drop rate calculation, item ID resolution, token claiming, and integration with the action system.

### Implementation Details

- Correctly handles namespace differences: demo skills (Woodcutting, Mining, etc.) use `melvorD:` while full game skills (Thieving, Crafting, etc.) use `melvorF:`
- Skills without mastery tokens (combat skills, Township, Alt. Magic) are properly excluded
- Drop rate increases as players unlock more actions within a skill
- Each claimed token adds 0.1% of the skill's maximum mastery pool XP (minimum 1 XP)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)