### PR TITLE
refactor: extract ActionImage widget to shared file

### DIFF
--- a/ui/lib/src/widgets/action_image.dart
+++ b/ui/lib/src/widgets/action_image.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:logic/logic.dart';
+import 'package:ui/src/widgets/cached_image.dart';
+import 'package:ui/src/widgets/context_extensions.dart';
+import 'package:ui/src/widgets/item_image.dart';
+import 'package:ui/src/widgets/style.dart';
+
+/// Returns the media path for an action, if available.
+/// Different action subclasses store media in different ways.
+String? mediaForAction(SkillAction action) {
+  // Check for specific action types that have media fields.
+  if (action is WoodcuttingTree) return action.media;
+  if (action is FishingAction) {
+    final media = action.media;
+    if (media.isNotEmpty) return media;
+  }
+  if (action is MiningAction) return action.media;
+  if (action is ThievingAction) return action.media;
+  if (action is AgilityObstacle) return 'assets/media/main/stamina.png';
+  if (action is AstrologyAction) return action.media;
+  if (action is AltMagicAction) return action.media;
+  // For other action types, return null (no direct media).
+  return null;
+}
+
+/// Returns the primary item ID for an action (output or input).
+/// Used for looking up item images when the action has no direct media.
+MelvorId? primaryItemIdForAction(SkillAction action) {
+  // Check for actions with productId fields.
+  if (action is FishingAction) return action.productId;
+  if (action is CookingAction) return action.productId;
+  if (action is FiremakingAction) return action.logId;
+  if (action is SummoningAction) return action.productId;
+  if (action is SmithingAction) return action.productId;
+  if (action is FletchingAction) return action.productId;
+  if (action is CraftingAction) return action.productId;
+  if (action is HerbloreAction) return action.productId;
+  if (action is RunecraftingAction) return action.productId;
+  // Fall back to first output or input.
+  if (action.outputs.isNotEmpty) return action.outputs.keys.first;
+  if (action.inputs.isNotEmpty) return action.inputs.keys.first;
+  return null;
+}
+
+/// Displays an image for an action, using its media path if available,
+/// or falling back to the primary item image.
+class ActionImage extends StatelessWidget {
+  const ActionImage({required this.action, this.size = 24, super.key});
+
+  final SkillAction action;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    // First try direct media path from action.
+    final media = mediaForAction(action);
+    if (media != null && media.isNotEmpty) {
+      return CachedImage(assetPath: media, size: size);
+    }
+
+    // Fall back to looking up the primary item's image.
+    final itemId = primaryItemIdForAction(action);
+    if (itemId != null) {
+      final items = context.state.registries.items;
+      final item = items.all.where((i) => i.id == itemId).firstOrNull;
+      if (item != null) {
+        return ItemImage(item: item, size: size);
+      }
+    }
+
+    // Last resort: show a generic icon.
+    return SizedBox(
+      width: size,
+      height: size,
+      child: Icon(
+        Icons.circle,
+        size: size * 0.67,
+        color: Style.iconColorDefault,
+      ),
+    );
+  }
+}

--- a/ui/lib/src/widgets/skill_milestones_dialog.dart
+++ b/ui/lib/src/widgets/skill_milestones_dialog.dart
@@ -1,42 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:logic/logic.dart';
-import 'package:ui/src/widgets/cached_image.dart';
+import 'package:ui/src/widgets/action_image.dart';
 import 'package:ui/src/widgets/context_extensions.dart';
-import 'package:ui/src/widgets/item_image.dart';
 import 'package:ui/src/widgets/skill_image.dart';
 import 'package:ui/src/widgets/style.dart';
-
-/// Returns the media path for an action, if available.
-/// Different action subclasses store media in different ways.
-String? _mediaForAction(SkillAction action) {
-  // Check for specific action types that have media fields.
-  if (action is WoodcuttingTree) return action.media;
-  if (action is FishingAction) {
-    final media = action.media;
-    if (media.isNotEmpty) return media;
-  }
-  if (action is MiningAction) return action.media;
-  if (action is ThievingAction) return action.media;
-  if (action is AgilityObstacle) return 'assets/media/main/stamina.png';
-  if (action is AstrologyAction) return action.media;
-  if (action is AltMagicAction) return action.media;
-  // For other action types, return null (no direct media).
-  return null;
-}
-
-/// Returns the primary item ID for an action (output or input).
-/// Used for looking up item images when the action has no direct media.
-MelvorId? _primaryItemId(SkillAction action) {
-  // Check for actions with productId fields.
-  if (action is FishingAction) return action.productId;
-  if (action is CookingAction) return action.productId;
-  if (action is FiremakingAction) return action.logId;
-  if (action is SummoningAction) return action.productId;
-  // Fall back to first output or input.
-  if (action.outputs.isNotEmpty) return action.outputs.keys.first;
-  if (action.inputs.isNotEmpty) return action.inputs.keys.first;
-  return null;
-}
 
 /// A dialog that displays the skill level milestones for a skill.
 /// Shows what actions unlock at each level.
@@ -145,7 +112,7 @@ class _SkillMilestonesTable extends StatelessWidget {
                 padding: const EdgeInsets.only(top: 8),
                 child: Row(
                   children: [
-                    _ActionImage(action: action),
+                    ActionImage(action: action),
                     const SizedBox(width: 8),
                     Expanded(child: Text(action.name)),
                   ],
@@ -155,39 +122,6 @@ class _SkillMilestonesTable extends StatelessWidget {
           );
         }),
       ],
-    );
-  }
-}
-
-/// Displays an image for an action, using its media path if available.
-class _ActionImage extends StatelessWidget {
-  const _ActionImage({required this.action});
-
-  final SkillAction action;
-
-  @override
-  Widget build(BuildContext context) {
-    // First try direct media path from action.
-    final media = _mediaForAction(action);
-    if (media != null && media.isNotEmpty) {
-      return CachedImage(assetPath: media, size: 24);
-    }
-
-    // Fall back to looking up the primary item's image.
-    final itemId = _primaryItemId(action);
-    if (itemId != null) {
-      final items = context.state.registries.items;
-      final item = items.all.where((i) => i.id == itemId).firstOrNull;
-      if (item != null) {
-        return ItemImage(item: item, size: 24);
-      }
-    }
-
-    // Last resort: show a generic icon.
-    return const SizedBox(
-      width: 24,
-      height: 24,
-      child: Icon(Icons.circle, size: 16, color: Style.iconColorDefault),
     );
   }
 }

--- a/ui/lib/src/widgets/spend_mastery_dialog.dart
+++ b/ui/lib/src/widgets/spend_mastery_dialog.dart
@@ -1,43 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:logic/logic.dart';
 import 'package:ui/src/logic/redux_actions.dart';
+import 'package:ui/src/widgets/action_image.dart';
 import 'package:ui/src/widgets/cached_image.dart';
-import 'package:ui/src/widgets/item_image.dart';
 import 'package:ui/src/widgets/skill_image.dart';
 import 'package:ui/src/widgets/style.dart';
-
-/// Returns the media path for an action, if available.
-/// Different action subclasses store media in different ways.
-String? _mediaForAction(SkillAction action) {
-  if (action is WoodcuttingTree) return action.media;
-  if (action is FishingAction) {
-    final media = action.media;
-    if (media.isNotEmpty) return media;
-  }
-  if (action is MiningAction) return action.media;
-  if (action is ThievingAction) return action.media;
-  if (action is AgilityObstacle) return 'assets/media/main/stamina.png';
-  if (action is AstrologyAction) return action.media;
-  if (action is AltMagicAction) return action.media;
-  return null;
-}
-
-/// Returns the primary item ID for an action (output or input).
-/// Used for looking up item images when the action has no direct media.
-MelvorId? _primaryItemId(SkillAction action) {
-  if (action is FishingAction) return action.productId;
-  if (action is CookingAction) return action.productId;
-  if (action is FiremakingAction) return action.logId;
-  if (action is SummoningAction) return action.productId;
-  if (action is SmithingAction) return action.productId;
-  if (action is FletchingAction) return action.productId;
-  if (action is CraftingAction) return action.productId;
-  if (action is HerbloreAction) return action.productId;
-  if (action is RunecraftingAction) return action.productId;
-  if (action.outputs.isNotEmpty) return action.outputs.keys.first;
-  if (action.inputs.isNotEmpty) return action.inputs.keys.first;
-  return null;
-}
 
 /// A dialog that lets the player spend mastery pool XP to level up action
 /// mastery levels.
@@ -214,7 +181,7 @@ class _ActionMasteryRow extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 8),
       child: Row(
         children: [
-          _ActionImage(action: action, state: state),
+          ActionImage(action: action),
           const SizedBox(width: 12),
           Expanded(
             child: Column(
@@ -387,41 +354,6 @@ class SpendMasteryButton extends StatelessWidget {
         size: 20,
       ),
       label: const Text('Spend Mastery'),
-    );
-  }
-}
-
-/// Displays an image for an action, using its media path if available.
-class _ActionImage extends StatelessWidget {
-  const _ActionImage({required this.action, required this.state});
-
-  final SkillAction action;
-  final GlobalState state;
-
-  @override
-  Widget build(BuildContext context) {
-    // First try direct media path from action.
-    final media = _mediaForAction(action);
-    if (media != null && media.isNotEmpty) {
-      return CachedImage(assetPath: media);
-    }
-
-    // Fall back to looking up the primary item's image.
-    final itemId = _primaryItemId(action);
-    if (itemId != null) {
-      final item = state.registries.items.all
-          .where((i) => i.id == itemId)
-          .firstOrNull;
-      if (item != null) {
-        return ItemImage(item: item);
-      }
-    }
-
-    // Last resort: show a generic icon.
-    return const SizedBox(
-      width: 32,
-      height: 32,
-      child: Icon(Icons.circle, size: 20, color: Style.iconColorDefault),
     );
   }
 }


### PR DESCRIPTION
## Summary
- Extract `ActionImage` widget and helper functions (`mediaForAction`, `primaryItemIdForAction`) to a new shared `action_image.dart` file
- Update `skill_milestones_dialog.dart` and `spend_mastery_dialog.dart` to use the shared widget
- Eliminates ~50 lines of duplicated code

## Test plan
- [x] Tests pass
- [x] Coverage at 90%
- [x] Spell check passes