### PR TITLE
refactor: make fishing area visibility data-driven

### DIFF
--- a/logic/lib/src/data/fishing.dart
+++ b/logic/lib/src/data/fishing.dart
@@ -15,6 +15,7 @@ class FishingArea {
     required this.fishIDs,
     this.requiredItemID,
     this.isSecret = false,
+    this.unlockedByItemID,
   });
 
   factory FishingArea.fromJson(
@@ -32,6 +33,14 @@ class FishingArea {
 
     final requiredItemIDJson = json['requiredItemID'] as String?;
 
+    final isSecret = json['isSecret'] as bool? ?? false;
+
+    // The JSON doesn't encode what unlocks secret areas, so we map it here.
+    // The Secret Area is unlocked by reading Message in a Bottle.
+    final unlockedByItemIDJson =
+        json['unlockedByItemID'] as String? ??
+        (isSecret ? 'melvorD:Message_In_A_Bottle' : null);
+
     return FishingArea(
       id: MelvorId.fromJsonWithNamespace(
         json['id'] as String,
@@ -48,7 +57,13 @@ class FishingArea {
               defaultNamespace: namespace,
             )
           : null,
-      isSecret: json['isSecret'] as bool? ?? false,
+      isSecret: isSecret,
+      unlockedByItemID: unlockedByItemIDJson != null
+          ? MelvorId.fromJsonWithNamespace(
+              unlockedByItemIDJson,
+              defaultNamespace: namespace,
+            )
+          : null,
     );
   }
 
@@ -60,6 +75,9 @@ class FishingArea {
   final List<MelvorId> fishIDs;
   final MelvorId? requiredItemID;
   final bool isSecret;
+
+  /// The readable item that must be read to unlock this area (for secret areas).
+  final MelvorId? unlockedByItemID;
 }
 
 /// A fishing action parsed from Melvor data.

--- a/logic/lib/src/state.dart
+++ b/logic/lib/src/state.dart
@@ -3453,12 +3453,6 @@ class GlobalState {
   /// Returns true if the given item has been read.
   bool hasReadItem(MelvorId itemId) => readItems.contains(itemId);
 
-  /// The ID of the Message in a Bottle item that unlocks the Secret Area.
-  static const _messageInABottleId = MelvorId('melvorD:Message_In_A_Bottle');
-
-  /// The ID of the Secret Fishing Area.
-  static const _secretFishingAreaId = MelvorId('melvorD:SecretArea');
-
   /// Reads an item, adding it to the set of read items.
   /// Returns the new state with the item marked as read.
   /// Throws if the item is not readable.
@@ -3480,22 +3474,15 @@ class GlobalState {
 
   /// Returns true if a fishing area is visible to the player.
   ///
-  /// Secret areas require reading the Message in a Bottle.
-  /// Areas with requiredItemID require having that item equipped.
+  /// Areas with [FishingArea.unlockedByItemID] require that item to be read.
+  /// Areas with [FishingArea.requiredItemID] require that item equipped.
   bool isFishingAreaVisible(FishingArea area) {
-    // Secret areas require unlocking by reading Message in a Bottle
-    if (area.isSecret) {
-      // The Secret Area is unlocked by reading the Message in a Bottle
-      if (area.id == _secretFishingAreaId) {
-        return hasReadItem(_messageInABottleId);
-      }
-      // Other secret areas would need their own unlock logic
-      return false;
+    if (area.unlockedByItemID != null) {
+      if (!hasReadItem(area.unlockedByItemID!)) return false;
     }
 
-    // Areas with required items need that item equipped
     if (area.requiredItemID != null) {
-      return equipment.hasItemEquipped(area.requiredItemID!);
+      if (!equipment.hasItemEquipped(area.requiredItemID!)) return false;
     }
 
     return true;

--- a/logic/test/data/fishing_test.dart
+++ b/logic/test/data/fishing_test.dart
@@ -273,5 +273,9 @@ void main() {
     test('message in a bottle is a readable item', () {
       expect(messageInABottle.isReadable, isTrue);
     });
+
+    test('secret area has unlockedByItemID set', () {
+      expect(secretArea.unlockedByItemID, messageInABottle.id);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Add `unlockedByItemID` field to `FishingArea`, populated at parse time (secret areas default to Message in a Bottle)
- Remove hardcoded `_messageInABottleId` and `_secretFishingAreaId` constants from `GlobalState`
- `isFishingAreaVisible` now checks area fields generically instead of matching specific IDs

## Test plan
- [x] Existing fishing area visibility tests pass
- [x] New test verifies `secretArea.unlockedByItemID` is correctly set
- [x] All 2191 tests pass