### PR TITLE
fix: replace LocalPersist with web-compatible GamePersist

### DIFF
--- a/ui/lib/main.dart
+++ b/ui/lib/main.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:async_redux/local_persist.dart';
 import 'package:flutter/material.dart';
 import 'package:logic/logic.dart';
 import 'package:scoped_deps/scoped_deps.dart';
@@ -8,6 +7,7 @@ import 'package:ui/src/logic/game_loop.dart';
 import 'package:ui/src/logic/redux_actions.dart';
 import 'package:ui/src/services/cache_factory.dart';
 import 'package:ui/src/services/cache_services.dart';
+import 'package:ui/src/services/game_persist.dart';
 import 'package:ui/src/services/logger.dart';
 import 'package:ui/src/services/save_slot_service.dart';
 import 'package:ui/src/services/toast_service.dart';
@@ -25,7 +25,7 @@ class MyPersistor extends Persistor<GlobalState> {
   final Registries registries;
   final int activeSlot;
 
-  LocalPersist get _persist => LocalPersist('melvor_slot_$activeSlot');
+  GamePersist get _persist => createGamePersist('melvor_slot_$activeSlot');
 
   @override
   Future<GlobalState> readState() async {

--- a/ui/lib/src/services/game_persist.dart
+++ b/ui/lib/src/services/game_persist.dart
@@ -1,0 +1,1 @@
+export 'game_persist_web.dart' if (dart.library.io) 'game_persist_native.dart';

--- a/ui/lib/src/services/game_persist_native.dart
+++ b/ui/lib/src/services/game_persist_native.dart
@@ -1,0 +1,15 @@
+import 'package:async_redux/local_persist.dart';
+
+/// Creates a platform-specific persist instance for the given [name].
+GamePersist createGamePersist(String name) => GamePersist._(name);
+
+/// Native file-system-based persistence using async_redux's LocalPersist.
+class GamePersist {
+  GamePersist._(String name) : _persist = LocalPersist(name);
+
+  final LocalPersist _persist;
+
+  Future<Object?> loadJson() async => _persist.loadJson();
+  Future<void> saveJson(Object? json) async => _persist.saveJson(json);
+  Future<void> delete() async => _persist.delete();
+}

--- a/ui/lib/src/services/game_persist_web.dart
+++ b/ui/lib/src/services/game_persist_web.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+
+import 'package:web/web.dart' as web;
+
+/// Creates a platform-specific persist instance for the given [name].
+GamePersist createGamePersist(String name) => GamePersist._(name);
+
+/// Web persistence using localStorage.
+class GamePersist {
+  GamePersist._(this._name);
+
+  final String _name;
+
+  String get _key => 'game_persist_$_name';
+
+  Future<Object?> loadJson() async {
+    final value = web.window.localStorage.getItem(_key);
+    if (value == null) return null;
+    return jsonDecode(value);
+  }
+
+  Future<void> saveJson(Object? json) async {
+    web.window.localStorage.setItem(_key, jsonEncode(json));
+  }
+
+  Future<void> delete() async {
+    web.window.localStorage.removeItem(_key);
+  }
+}

--- a/ui/lib/src/services/save_slot_service.dart
+++ b/ui/lib/src/services/save_slot_service.dart
@@ -1,5 +1,5 @@
-import 'package:async_redux/local_persist.dart';
 import 'package:flutter/material.dart';
+import 'package:ui/src/services/game_persist.dart';
 import 'package:ui/src/services/logger.dart';
 
 /// Metadata about all save slots.
@@ -69,7 +69,7 @@ const int saveSlotCount = 3;
 class SaveSlotService {
   SaveSlotService._();
 
-  static final LocalPersist _metaPersist = LocalPersist('melvor_meta');
+  static final GamePersist _metaPersist = createGamePersist('melvor_meta');
 
   /// Load save slot metadata.
   static Future<SaveSlotMeta> loadMeta() async {
@@ -99,12 +99,12 @@ class SaveSlotService {
     }
 
     // Check for old-style save
-    final oldPersist = LocalPersist('better_idle');
+    final oldPersist = createGamePersist('better_idle');
     final oldData = await oldPersist.loadJson();
 
     if (oldData != null) {
       // Migrate to slot 0
-      final slot0Persist = LocalPersist('melvor_slot_0');
+      final slot0Persist = createGamePersist('melvor_slot_0');
       await slot0Persist.saveJson(oldData);
 
       // Create meta with slot 0 active
@@ -125,7 +125,7 @@ class SaveSlotService {
 
   /// Delete a specific slot's data.
   static Future<void> deleteSlot(int slot) async {
-    final slotPersist = LocalPersist('melvor_slot_$slot');
+    final slotPersist = createGamePersist('melvor_slot_$slot');
     await slotPersist.delete();
 
     // Update meta

--- a/ui/pubspec.lock
+++ b/ui/pubspec.lock
@@ -486,7 +486,7 @@ packages:
     source: hosted
     version: "4.0.1"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/ui/pubspec.yaml
+++ b/ui/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
     path: ../logic
   meta: any
   path_provider: ^2.1.5
+  web: ^1.1.0
   scoped_deps:
     git:
       url: https://github.com/shorebirdtech/shorebird.git


### PR DESCRIPTION
## Summary
- Follow-up to #113 — `LocalPersist` from async_redux uses `dart:io` file system internally, crashing on web with `Unsupported operation: _Namespace`
- Created `GamePersist` abstraction with conditional imports: `LocalPersist` wrapper on native, `localStorage` on web
- Added `web` package dependency for `localStorage` access

## Test plan
- [x] `dart test -r failures-only` in logic/ (2191 pass)
- [x] `flutter test --reporter failures-only` in ui/ (151 pass)
- [x] `flutter build web` succeeds
- [x] `npx cspell` passes
- [x] `dart format .` and `dart fix --apply .` clean