### PR TITLE
feat: add affordable-only filter toggle to shop

### DIFF
--- a/ui/pubspec.lock
+++ b/ui/pubspec.lock
@@ -433,10 +433,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Adds a filter icon button in the shop app bar that toggles "show affordable only" mode
- When active, hides items the player can't afford (unmet requirements, insufficient currency, or missing item costs)
- Hides category headers entirely when all items in that category are filtered out

## Test plan
- [ ] Open shop, verify filter icon (outlined) appears in app bar
- [ ] Tap filter icon — only affordable items shown, icon becomes filled
- [ ] Verify empty categories are hidden
- [ ] Tap again to disable — all items reappear