### PR TITLE
Add diagnostics for white screen on web resume

### DIFF
--- a/ui/lib/main.dart
+++ b/ui/lib/main.dart
@@ -229,8 +229,10 @@ class _AppLifecycleManagerState extends State<_AppLifecycleManager>
           ProcessLifecycleChangeAction(LifecycleChange.pause),
         );
       case AppLifecycleState.resumed:
-        logger.info('Resuming: time since update='
-            '${DateTime.timestamp().difference(widget.store.state.updatedAt)}');
+        logger.info(
+          'Resuming: time since update='
+          '${DateTime.timestamp().difference(widget.store.state.updatedAt)}',
+        );
         // Calculate time away and process it
         widget.store.dispatch(ResumeFromPauseAction());
         logger.info('ResumeFromPauseAction dispatched');

--- a/ui/lib/src/logic/redux_actions.dart
+++ b/ui/lib/src/logic/redux_actions.dart
@@ -135,8 +135,10 @@ class ResumeFromPauseAction extends ReduxAction<GlobalState> {
       random: random,
     );
     stopwatch.stop();
-    logger.info('ResumeFromPause: consumeManyTicks took '
-        '${stopwatch.elapsedMilliseconds}ms');
+    logger.info(
+      'ResumeFromPause: consumeManyTicks took '
+      '${stopwatch.elapsedMilliseconds}ms',
+    );
     final timeAway = newTimeAway.maybeMergeInto(state.timeAway);
     // Set timeAway on state if it has changes - empty timeAway should be null
     return newState.copyWith(


### PR DESCRIPTION
## Summary
- Add `FlutterError.onError` and `PlatformDispatcher.instance.onError` global error handlers to catch and log uncaught exceptions
- Add lifecycle state logging in `_AppLifecycleManager` to trace hidden/paused/resumed transitions
- Add timing and context logging in `ResumeFromPauseAction` to measure `consumeManyTicks` duration

## Context
The web app intermittently shows an all-white screen when returning to any page after the tab has been backgrounded. Reloading fixes it. These diagnostics will help identify whether the cause is:
- A WebGL context loss (no logs in console at all)
- An uncaught exception in the resume path (error logged)
- `consumeManyTicks` blocking the UI thread too long (timing logged)
- A Flutter web rendering bug after state update (all logs normal)

## Test plan
- [ ] Deploy to web, leave tab in background, return — check console for new log output
- [ ] Verify no regressions in normal lifecycle flow