### PR TITLE
Cap mastery level at 99 and use level getters

### DIFF
--- a/logic/lib/src/action_state.dart
+++ b/logic/lib/src/action_state.dart
@@ -226,7 +226,8 @@ class ActionState {
   }
 
   /// The mastery level for this action, derived from mastery XP.
-  int get masteryLevel => levelForXp(masteryXp);
+  /// Capped at 99 even if XP exceeds the level 99 threshold.
+  int get masteryLevel => levelForXp(masteryXp).clamp(1, 99);
 
   ActionState copyWith({
     int? masteryXp,

--- a/logic/lib/src/activity/mining_persistent_state.dart
+++ b/logic/lib/src/activity/mining_persistent_state.dart
@@ -82,7 +82,7 @@ class MiningState {
 
   /// Gets the current HP of a mining rock.
   int currentHp(MiningAction action, int masteryXp) {
-    final masteryLevel = levelForXp(masteryXp);
+    final masteryLevel = levelForXp(masteryXp).clamp(1, 99);
     final maxHp = action.maxHpForMasteryLevel(masteryLevel);
     return max(0, maxHp - totalHpLost);
   }

--- a/logic/lib/src/solver/analysis/next_decision_delta.dart
+++ b/logic/lib/src/solver/analysis/next_decision_delta.dart
@@ -560,7 +560,7 @@ _DeltaCandidate? _deltaUntilNextSkillLevel(
   if (xpRate == null || xpRate <= 0) return null;
 
   final currentXp = state.skillState(skill).xp;
-  final currentLevel = levelForXp(currentXp);
+  final currentLevel = state.skillState(skill).skillLevel;
 
   // Find the next unlock level for any locked activity of this skill
   int? nextUnlockLevel;

--- a/logic/lib/src/state_update_builder.dart
+++ b/logic/lib/src/state_update_builder.dart
@@ -81,7 +81,7 @@ class StateUpdateBuilder {
   }
 
   int currentMasteryLevel(Action action) {
-    return levelForXp(_state.actionState(action.id).masteryXp);
+    return _state.actionState(action.id).masteryLevel;
   }
 
   void restartCurrentAction(Action action, {required Random random}) {

--- a/ui/lib/src/screens/agility.dart
+++ b/ui/lib/src/screens/agility.dart
@@ -473,8 +473,7 @@ class _ObstacleSlotCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final state = context.state;
     final skillState = state.skillState(Skill.agility);
-    final skillLevel = levelForXp(skillState.xp);
-    final isUnlocked = skillLevel >= slotLevel;
+    final isUnlocked = skillState.skillLevel >= slotLevel;
 
     // Check if this obstacle is currently being run
     final activity = state.activeActivity;

--- a/ui/lib/src/screens/fishing.dart
+++ b/ui/lib/src/screens/fishing.dart
@@ -27,7 +27,7 @@ class _FishingPageState extends State<FishingPage> {
     const skill = Skill.fishing;
     final state = context.state;
     final skillState = state.skillState(skill);
-    final skillLevel = levelForXp(skillState.xp);
+    final skillLevel = skillState.skillLevel;
     final registries = state.registries;
 
     // Get all fishing actions from registries.

--- a/ui/lib/src/screens/thieving.dart
+++ b/ui/lib/src/screens/thieving.dart
@@ -134,8 +134,8 @@ class _SelectedActionDisplay extends StatelessWidget {
     final canToggle = (canStart || isActive) && !isStunned;
 
     // Calculate stealth and success chance
-    final thievingLevel = levelForXp(state.skillState(Skill.thieving).xp);
-    final masteryLevel = levelForXp(actionState.masteryXp);
+    final thievingLevel = state.skillState(Skill.thieving).skillLevel;
+    final masteryLevel = actionState.masteryLevel;
     final stealth = calculateStealth(thievingLevel, masteryLevel);
     final successChance = ((100 + stealth) / (100 + action.perception)).clamp(
       0.0,
@@ -367,7 +367,7 @@ class _ActionList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final skillState = context.state.skillState(Skill.thieving);
-    final skillLevel = levelForXp(skillState.xp);
+    final skillLevel = skillState.skillLevel;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -456,10 +456,10 @@ class _ActionList extends StatelessWidget {
                   // Calculate success chance for this action
                   final state = context.state;
                   final actionState = state.actionState(action.id);
-                  final thievingLevel = levelForXp(
-                    state.skillState(Skill.thieving).xp,
-                  );
-                  final masteryLevel = levelForXp(actionState.masteryXp);
+                  final thievingLevel = state
+                      .skillState(Skill.thieving)
+                      .skillLevel;
+                  final masteryLevel = actionState.masteryLevel;
                   final stealth = calculateStealth(thievingLevel, masteryLevel);
                   final successChance = thievingSuccessChance(
                     stealth,

--- a/ui/lib/src/widgets/action_grid.dart
+++ b/ui/lib/src/widgets/action_grid.dart
@@ -223,8 +223,7 @@ class WoodcuttingActionCell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final skillState = context.state.skillState(action.skill);
-    final skillLevel = levelForXp(skillState.xp);
-    final isUnlocked = skillLevel >= action.unlockLevel;
+    final isUnlocked = skillState.skillLevel >= action.unlockLevel;
 
     if (!isUnlocked) {
       return LockedActionCell(
@@ -286,8 +285,7 @@ class MiningActionCell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final skillState = context.state.skillState(action.skill);
-    final skillLevel = levelForXp(skillState.xp);
-    final isUnlocked = skillLevel >= action.unlockLevel;
+    final isUnlocked = skillState.skillLevel >= action.unlockLevel;
 
     if (!isUnlocked) {
       return LockedActionCell(
@@ -309,9 +307,8 @@ class MiningActionCell extends StatelessWidget {
     final isRunning = state.isActionActive(action);
     final isStunned = state.isStunned;
 
-    final masteryLevel = levelForXp(actionState.masteryXp);
     final miningState = state.miningState.rockState(action.id.localId);
-    final maxHp = action.maxHpForMasteryLevel(masteryLevel);
+    final maxHp = action.maxHpForMasteryLevel(actionState.masteryLevel);
     final currentHp = miningState.currentHp(action, actionState.masteryXp);
 
     Duration? respawnTimeRemaining;
@@ -400,8 +397,7 @@ class AstrologyActionCell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final skillState = context.state.skillState(action.skill);
-    final skillLevel = levelForXp(skillState.xp);
-    final isUnlocked = skillLevel >= action.unlockLevel;
+    final isUnlocked = skillState.skillLevel >= action.unlockLevel;
 
     if (!isUnlocked) {
       return LockedActionCell(
@@ -497,8 +493,7 @@ class ActionCell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final skillState = context.state.skillState(action.skill);
-    final skillLevel = levelForXp(skillState.xp);
-    final isUnlocked = skillLevel >= action.unlockLevel;
+    final isUnlocked = skillState.skillLevel >= action.unlockLevel;
 
     if (!isUnlocked) {
       return _buildLocked(context);

--- a/ui/lib/src/widgets/navigation_drawer.dart
+++ b/ui/lib/src/widgets/navigation_drawer.dart
@@ -92,7 +92,7 @@ class SkillTile extends StatelessWidget {
     final isActiveSkill = activeSkill == skill;
     final isSelected = selected || currentLocation == '/$routeName';
     final skillState = context.state.skillState(skill);
-    final level = levelForXp(skillState.xp);
+    final level = skillState.skillLevel;
 
     const valueStyle = TextStyle(color: Style.currencyValueColor);
     final slayerCoins = context.state.currency(Currency.slayerCoins);

--- a/ui/lib/src/widgets/skill_milestones_dialog.dart
+++ b/ui/lib/src/widgets/skill_milestones_dialog.dart
@@ -16,7 +16,7 @@ class SkillMilestonesDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final state = context.state;
     final skillState = state.skillState(skill);
-    final currentLevel = levelForXp(skillState.xp);
+    final currentLevel = skillState.skillLevel;
 
     // Get all skill actions for this skill, sorted by unlock level.
     final actions = state.registries.actionsForSkill(skill).toList()


### PR DESCRIPTION
## Summary
- Cap `ActionState.masteryLevel` at 99 via `.clamp(1, 99)`, even if accumulated XP exceeds the level 99 threshold (XP continues to accumulate uncapped)
- Replace all direct `levelForXp()` calls in UI and logic with `skillState.skillLevel` or `actionState.masteryLevel` getters
- No remaining direct `levelForXp()` usage outside of the getter definitions themselves and one internal use in `mining_persistent_state.dart`

## Test plan
- [x] All logic tests pass
- [x] All UI tests pass