### PR TITLE
feat: add bulk purchasing to shop

### DIFF
--- a/logic/lib/src/data/shop.dart
+++ b/logic/lib/src/data/shop.dart
@@ -82,8 +82,9 @@ class ShopCost extends Equatable {
     return null;
   }
 
-  /// Returns true if this purchase uses the bank slot pricing formula.
-  bool get _usesBankSlotPricing {
+  /// Returns true if this purchase uses dynamic pricing (e.g., bank slots)
+  /// where cost changes after each purchase.
+  bool get hasDynamicPricing {
     return currencies.any(
       (c) => c.currency == Currency.gp && c.type == CostType.bankSlot,
     );
@@ -105,7 +106,7 @@ class ShopCost extends Equatable {
   /// For purchases with dynamic bank slot pricing, calculates the cost
   /// based on [bankSlotsPurchased]. For fixed pricing, returns the fixed costs.
   List<(Currency, int)> currencyCosts({required int bankSlotsPurchased}) {
-    if (_usesBankSlotPricing) {
+    if (hasDynamicPricing) {
       final cost = calculateBankSlotCost(bankSlotsPurchased);
       return [(Currency.gp, cost)];
     }

--- a/ui/lib/src/logic/redux_actions.dart
+++ b/ui/lib/src/logic/redux_actions.dart
@@ -192,12 +192,17 @@ class UpgradeItemAction extends ReduxAction<GlobalState> {
 
 /// Purchases a shop item (skill upgrade or other purchase).
 class PurchaseShopItemAction extends ReduxAction<GlobalState> {
-  PurchaseShopItemAction({required this.purchaseId});
+  PurchaseShopItemAction({required this.purchaseId, this.count = 1});
   final MelvorId purchaseId;
+  final int count;
 
   @override
   GlobalState reduce() {
-    return state.purchaseShopItem(purchaseId);
+    var newState = state;
+    for (var i = 0; i < count; i++) {
+      newState = newState.purchaseShopItem(purchaseId);
+    }
+    return newState;
   }
 }
 

--- a/ui/lib/src/widgets/shard_purchase_dialog.dart
+++ b/ui/lib/src/widgets/shard_purchase_dialog.dart
@@ -394,12 +394,12 @@ class _QuantityButtons extends StatelessWidget {
           TextButton(
             onPressed: () {
               try {
-                // Execute purchase multiple times
-                for (var i = 0; i < quantity; i++) {
-                  context.dispatch(
-                    PurchaseShopItemAction(purchaseId: purchase.id),
-                  );
-                }
+                context.dispatch(
+                  PurchaseShopItemAction(
+                    purchaseId: purchase.id,
+                    count: quantity,
+                  ),
+                );
                 Navigator.of(dialogContext).pop();
                 Navigator.of(context).pop();
               } on Exception catch (e) {


### PR DESCRIPTION
## Summary
- Adds a quantity selector dialog for shop items that support multiple purchases (unlimited items, bank slots, item charge packs, etc.)
- Items with only 1 remaining purchase keep the existing simple confirm dialog
- Quantity presets (1, 10, 100, 1k, 10k), Max, and Custom buttons with live total cost display
- Handles dynamic pricing (bank slots) correctly by summing per-unit escalating costs
- Makes shard dialog purchases atomic via a single `PurchaseShopItemAction(count: N)` instead of N separate dispatches

## Test plan
- [x] `dart test` passes in both logic/ and ui/
- [x] `dart format .` and `dart fix --apply .` clean
- [x] `npx cspell` passes
- [ ] Manual: tap an unlimited shop item → see quantity selector → buy multiple → verify costs deducted
- [ ] Manual: tap a buyLimit=1 item → see simple confirm dialog (unchanged)
- [ ] Manual: tap bank slots → verify escalating total cost display