### PR TITLE
Add quick equip FAB to skill pages

### DIFF
--- a/logic/lib/src/data/items.dart
+++ b/logic/lib/src/data/items.dart
@@ -517,6 +517,19 @@ class Item extends Equatable {
   /// Returns true if this item can be equipped in the given slot.
   bool canEquipInSlot(EquipmentSlot slot) => validSlots.contains(slot);
 
+  /// Whether any of this item's modifiers are relevant to [skillId].
+  ///
+  /// Returns true if any modifier entry applies to the skill (including
+  /// global/unscoped modifiers that apply to all skills).
+  bool hasModifiersForSkill(MelvorId skillId) {
+    for (final mod in modifiers.modifiers) {
+      for (final entry in mod.entries) {
+        if (entry.appliesToSkill(skillId)) return true;
+      }
+    }
+    return false;
+  }
+
   /// Opens this item once and returns the resulting drop.
   /// Throws if the item is not openable.
   ItemStack open(ItemRegistry items, Random random) {

--- a/logic/test/data/items_skill_relevance_test.dart
+++ b/logic/test/data/items_skill_relevance_test.dart
@@ -1,0 +1,86 @@
+import 'package:logic/logic.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Item.hasModifiersForSkill', () {
+    const woodcuttingId = MelvorId('melvorD:Woodcutting');
+    const fishingId = MelvorId('melvorD:Fishing');
+
+    test('returns true for item with matching skill modifier', () {
+      const item = Item(
+        id: MelvorId('melvorD:Test_Item'),
+        name: 'Test Item',
+        itemType: 'Equipment',
+        sellsFor: 10,
+        validSlots: [EquipmentSlot.ring],
+        modifiers: ModifierDataSet([
+          ModifierData(
+            name: 'skillXP',
+            entries: [
+              ModifierEntry(
+                value: 5,
+                scope: ModifierScope(skillId: woodcuttingId),
+              ),
+            ],
+          ),
+        ]),
+      );
+
+      expect(item.hasModifiersForSkill(woodcuttingId), isTrue);
+    });
+
+    test('returns false for item with non-matching skill modifier', () {
+      const item = Item(
+        id: MelvorId('melvorD:Test_Item'),
+        name: 'Test Item',
+        itemType: 'Equipment',
+        sellsFor: 10,
+        validSlots: [EquipmentSlot.ring],
+        modifiers: ModifierDataSet([
+          ModifierData(
+            name: 'skillXP',
+            entries: [
+              ModifierEntry(
+                value: 5,
+                scope: ModifierScope(skillId: woodcuttingId),
+              ),
+            ],
+          ),
+        ]),
+      );
+
+      expect(item.hasModifiersForSkill(fishingId), isFalse);
+    });
+
+    test('returns true for item with global modifier', () {
+      const item = Item(
+        id: MelvorId('melvorD:Test_Item'),
+        name: 'Test Item',
+        itemType: 'Equipment',
+        sellsFor: 10,
+        validSlots: [EquipmentSlot.ring],
+        modifiers: ModifierDataSet([
+          ModifierData(
+            name: 'doubleItemsSkill',
+            entries: [ModifierEntry(value: 5)],
+          ),
+        ]),
+      );
+
+      expect(item.hasModifiersForSkill(woodcuttingId), isTrue);
+      expect(item.hasModifiersForSkill(fishingId), isTrue);
+    });
+
+    test('returns false for item with no modifiers', () {
+      const item = Item(
+        id: MelvorId('melvorD:Test_Item'),
+        name: 'Test Item',
+        itemType: 'Equipment',
+        sellsFor: 10,
+        validSlots: [EquipmentSlot.ring],
+      );
+
+      expect(item.hasModifiersForSkill(woodcuttingId), isFalse);
+    });
+  });
+}

--- a/ui/lib/src/screens/agility.dart
+++ b/ui/lib/src/screens/agility.dart
@@ -5,6 +5,7 @@ import 'package:ui/src/widgets/cached_image.dart';
 import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/game_scaffold.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
+import 'package:ui/src/widgets/skill_fab.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
 import 'package:ui/src/widgets/skill_progress.dart';
 import 'package:ui/src/widgets/style.dart';
@@ -67,6 +68,7 @@ class AgilityPage extends StatelessWidget {
     return GameScaffold(
       title: const Text('Agility'),
       actions: const [SkillOverflowMenu(skill: skill)],
+      floatingActionButton: const SkillFab(skill: skill),
       body: Column(
         children: [
           SkillProgress(xp: skillState.xp),

--- a/ui/lib/src/screens/alt_magic.dart
+++ b/ui/lib/src/screens/alt_magic.dart
@@ -7,6 +7,7 @@ import 'package:ui/src/widgets/game_scaffold.dart';
 import 'package:ui/src/widgets/input_items_row.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
 import 'package:ui/src/widgets/skill_action_display.dart';
+import 'package:ui/src/widgets/skill_fab.dart';
 import 'package:ui/src/widgets/skill_image.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
 import 'package:ui/src/widgets/skill_progress.dart';
@@ -46,6 +47,7 @@ class AltMagicPage extends StatelessWidget {
     return GameScaffold(
       title: const Text('Alt. Magic'),
       actions: const [SkillOverflowMenu(skill: skill)],
+      floatingActionButton: const SkillFab(skill: skill),
       body: Column(
         children: [
           SkillProgress(xp: skillState.xp),

--- a/ui/lib/src/screens/cooking.dart
+++ b/ui/lib/src/screens/cooking.dart
@@ -12,6 +12,7 @@ import 'package:ui/src/widgets/item_count_badge_cell.dart';
 import 'package:ui/src/widgets/item_image.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
 import 'package:ui/src/widgets/recycle_chance_badge_cell.dart';
+import 'package:ui/src/widgets/skill_fab.dart';
 import 'package:ui/src/widgets/skill_image.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
 import 'package:ui/src/widgets/skill_progress.dart';
@@ -30,6 +31,7 @@ class CookingPage extends StatelessWidget {
     return GameScaffold(
       title: const Text('Cooking'),
       actions: const [SkillOverflowMenu(skill: skill)],
+      floatingActionButton: const SkillFab(skill: skill),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: Column(

--- a/ui/lib/src/screens/crafting.dart
+++ b/ui/lib/src/screens/crafting.dart
@@ -6,6 +6,7 @@ import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/game_scaffold.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
 import 'package:ui/src/widgets/production_action_display.dart';
+import 'package:ui/src/widgets/skill_fab.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
 import 'package:ui/src/widgets/skill_progress.dart';
 
@@ -50,6 +51,7 @@ class _CraftingPageState extends State<CraftingPage> {
     return GameScaffold(
       title: const Text('Crafting'),
       actions: const [SkillOverflowMenu(skill: skill)],
+      floatingActionButton: const SkillFab(skill: skill),
       body: Column(
         children: [
           SkillProgress(xp: skillState.xp),

--- a/ui/lib/src/screens/farming.dart
+++ b/ui/lib/src/screens/farming.dart
@@ -6,6 +6,7 @@ import 'package:ui/src/widgets/cost_row.dart';
 import 'package:ui/src/widgets/game_scaffold.dart';
 import 'package:ui/src/widgets/item_image.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
+import 'package:ui/src/widgets/skill_fab.dart';
 import 'package:ui/src/widgets/skill_image.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
 import 'package:ui/src/widgets/skill_progress.dart';
@@ -32,6 +33,7 @@ class FarmingPage extends StatelessWidget {
     return GameScaffold(
       title: const Text('Farming'),
       actions: const [SkillOverflowMenu(skill: skill)],
+      floatingActionButton: const SkillFab(skill: skill),
       body: Column(
         children: [
           SkillProgress(xp: skillState.xp),

--- a/ui/lib/src/screens/firemaking.dart
+++ b/ui/lib/src/screens/firemaking.dart
@@ -11,6 +11,7 @@ import 'package:ui/src/widgets/item_count_badge_cell.dart';
 import 'package:ui/src/widgets/item_image.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
 import 'package:ui/src/widgets/recycle_chance_badge_cell.dart';
+import 'package:ui/src/widgets/skill_fab.dart';
 import 'package:ui/src/widgets/skill_image.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
 import 'package:ui/src/widgets/skill_progress.dart';
@@ -62,6 +63,7 @@ class FiremakingPage extends StatelessWidget {
     return GameScaffold(
       title: const Text('Firemaking'),
       actions: const [SkillOverflowMenu(skill: skill)],
+      floatingActionButton: const SkillFab(skill: skill),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
         child: Column(

--- a/ui/lib/src/screens/fishing.dart
+++ b/ui/lib/src/screens/fishing.dart
@@ -7,6 +7,7 @@ import 'package:ui/src/widgets/game_scaffold.dart';
 import 'package:ui/src/widgets/item_image.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
 import 'package:ui/src/widgets/skill_action_display.dart';
+import 'package:ui/src/widgets/skill_fab.dart';
 import 'package:ui/src/widgets/skill_image.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
 import 'package:ui/src/widgets/skill_progress.dart';
@@ -80,6 +81,7 @@ class _FishingPageState extends State<FishingPage> {
     return GameScaffold(
       title: const Text('Fishing'),
       actions: const [SkillOverflowMenu(skill: skill)],
+      floatingActionButton: const SkillFab(skill: skill),
       body: Column(
         children: [
           SkillProgress(xp: skillState.xp),

--- a/ui/lib/src/screens/fletching.dart
+++ b/ui/lib/src/screens/fletching.dart
@@ -6,6 +6,7 @@ import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/game_scaffold.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
 import 'package:ui/src/widgets/production_action_display.dart';
+import 'package:ui/src/widgets/skill_fab.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
 import 'package:ui/src/widgets/skill_progress.dart';
 
@@ -50,6 +51,7 @@ class _FletchingPageState extends State<FletchingPage> {
     return GameScaffold(
       title: const Text('Fletching'),
       actions: const [SkillOverflowMenu(skill: skill)],
+      floatingActionButton: const SkillFab(skill: skill),
       body: Column(
         children: [
           SkillProgress(xp: skillState.xp),

--- a/ui/lib/src/screens/herblore.dart
+++ b/ui/lib/src/screens/herblore.dart
@@ -6,6 +6,7 @@ import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/game_scaffold.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
 import 'package:ui/src/widgets/production_action_display.dart';
+import 'package:ui/src/widgets/skill_fab.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
 import 'package:ui/src/widgets/skill_progress.dart';
 
@@ -50,6 +51,7 @@ class _HerblorePageState extends State<HerblorePage> {
     return GameScaffold(
       title: const Text('Herblore'),
       actions: const [SkillOverflowMenu(skill: skill)],
+      floatingActionButton: const SkillFab(skill: skill),
       body: Column(
         children: [
           SkillProgress(xp: skillState.xp),

--- a/ui/lib/src/screens/runecrafting.dart
+++ b/ui/lib/src/screens/runecrafting.dart
@@ -8,6 +8,7 @@ import 'package:ui/src/widgets/input_items_row.dart';
 import 'package:ui/src/widgets/item_image.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
 import 'package:ui/src/widgets/production_action_display.dart';
+import 'package:ui/src/widgets/skill_fab.dart';
 import 'package:ui/src/widgets/skill_image.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
 import 'package:ui/src/widgets/skill_progress.dart';
@@ -80,6 +81,7 @@ class _RunecraftingPageState extends State<RunecraftingPage>
     return GameScaffold(
       title: const Text('Runecrafting'),
       actions: const [SkillOverflowMenu(skill: skill)],
+      floatingActionButton: const SkillFab(skill: skill),
       body: Column(
         children: [
           SkillProgress(xp: skillState.xp),

--- a/ui/lib/src/screens/smithing.dart
+++ b/ui/lib/src/screens/smithing.dart
@@ -6,6 +6,7 @@ import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/game_scaffold.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
 import 'package:ui/src/widgets/production_action_display.dart';
+import 'package:ui/src/widgets/skill_fab.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
 import 'package:ui/src/widgets/skill_progress.dart';
 
@@ -50,6 +51,7 @@ class _SmithingPageState extends State<SmithingPage> {
     return GameScaffold(
       title: const Text('Smithing'),
       actions: const [SkillOverflowMenu(skill: skill)],
+      floatingActionButton: const SkillFab(skill: skill),
       body: Column(
         children: [
           SkillProgress(xp: skillState.xp),

--- a/ui/lib/src/screens/summoning.dart
+++ b/ui/lib/src/screens/summoning.dart
@@ -8,6 +8,7 @@ import 'package:ui/src/widgets/item_image.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
 import 'package:ui/src/widgets/production_action_display.dart';
 import 'package:ui/src/widgets/shard_purchase_dialog.dart';
+import 'package:ui/src/widgets/skill_fab.dart';
 import 'package:ui/src/widgets/skill_image.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
 import 'package:ui/src/widgets/skill_progress.dart';
@@ -87,6 +88,7 @@ class _SummoningPageState extends State<SummoningPage>
     return GameScaffold(
       title: const Text('Summoning'),
       actions: const [SkillOverflowMenu(skill: skill)],
+      floatingActionButton: const SkillFab(skill: skill),
       body: Column(
         children: [
           SkillProgress(xp: skillState.xp),

--- a/ui/lib/src/screens/thieving.dart
+++ b/ui/lib/src/screens/thieving.dart
@@ -6,6 +6,7 @@ import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/game_scaffold.dart';
 import 'package:ui/src/widgets/hp_bar.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
+import 'package:ui/src/widgets/skill_fab.dart';
 import 'package:ui/src/widgets/skill_image.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
 import 'package:ui/src/widgets/skill_progress.dart';
@@ -57,6 +58,7 @@ class _ThievingPageState extends State<ThievingPage> {
     return GameScaffold(
       title: const Text('Thieving'),
       actions: const [SkillOverflowMenu(skill: skill)],
+      floatingActionButton: const SkillFab(skill: skill),
       body: Column(
         children: [
           SkillProgress(xp: skillState.xp),

--- a/ui/lib/src/widgets/expandable_fab.dart
+++ b/ui/lib/src/widgets/expandable_fab.dart
@@ -1,0 +1,185 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// Data for a single action button in the expandable FAB.
+class ExpandableFabAction {
+  const ExpandableFabAction({
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onPressed;
+}
+
+/// An expandable floating action button that reveals child actions
+/// when tapped.
+///
+/// Shows a main FAB that rotates when expanded, revealing labeled
+/// action buttons stacked above it.
+class ExpandableFab extends StatefulWidget {
+  const ExpandableFab({required this.actions, super.key});
+
+  final List<ExpandableFabAction> actions;
+
+  @override
+  State<ExpandableFab> createState() => _ExpandableFabState();
+}
+
+class _ExpandableFabState extends State<ExpandableFab>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _expandAnimation;
+  bool _isOpen = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 200),
+    );
+    _expandAnimation = CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeOut,
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _toggle() {
+    setState(() {
+      _isOpen = !_isOpen;
+      if (_isOpen) {
+        _controller.forward();
+      } else {
+        _controller.reverse();
+      }
+    });
+  }
+
+  void _close() {
+    if (_isOpen) _toggle();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      // Reserve space for expanded actions.
+      width: 200,
+      height: 56.0 + widget.actions.length * 48.0 + 16,
+      child: Stack(
+        alignment: Alignment.bottomRight,
+        children: [
+          // Scrim to dismiss when tapping outside.
+          if (_isOpen)
+            Positioned.fill(
+              child: GestureDetector(
+                onTap: _close,
+                behavior: HitTestBehavior.opaque,
+                child: const SizedBox.expand(),
+              ),
+            ),
+          // Child action buttons.
+          ..._buildActions(),
+          // Main FAB.
+          FloatingActionButton(
+            onPressed: _toggle,
+            child: AnimatedBuilder(
+              animation: _expandAnimation,
+              builder: (context, child) {
+                return Transform.rotate(
+                  angle: _expandAnimation.value * math.pi / 4,
+                  child: child,
+                );
+              },
+              child: const Icon(Icons.handyman),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildActions() {
+    final children = <Widget>[];
+    for (var i = 0; i < widget.actions.length; i++) {
+      final action = widget.actions[i];
+      // Stack from bottom: first action closest to
+      // main FAB.
+      final offset = (i + 1) * 48.0 + 8.0;
+      children.add(
+        AnimatedBuilder(
+          animation: _expandAnimation,
+          builder: (context, child) {
+            return Positioned(
+              right: 4,
+              bottom: offset * _expandAnimation.value,
+              child: Opacity(opacity: _expandAnimation.value, child: child),
+            );
+          },
+          child: _ActionButton(
+            icon: action.icon,
+            label: action.label,
+            onPressed: () {
+              _close();
+              action.onPressed();
+            },
+          ),
+        ),
+      );
+    }
+    return children;
+  }
+}
+
+/// A small labeled action button shown when the FAB is expanded.
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({
+    required this.icon,
+    required this.label,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceContainerHigh,
+            borderRadius: BorderRadius.circular(4),
+            boxShadow: const [
+              BoxShadow(
+                color: Colors.black26,
+                blurRadius: 4,
+                offset: Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Text(label, style: theme.textTheme.bodySmall),
+        ),
+        const SizedBox(width: 8),
+        FloatingActionButton.small(
+          heroTag: label,
+          onPressed: onPressed,
+          child: Icon(icon),
+        ),
+      ],
+    );
+  }
+}

--- a/ui/lib/src/widgets/quick_equip_dialog.dart
+++ b/ui/lib/src/widgets/quick_equip_dialog.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/material.dart';
+import 'package:logic/logic.dart';
+import 'package:ui/src/logic/redux_actions.dart';
+import 'package:ui/src/widgets/context_extensions.dart';
+import 'package:ui/src/widgets/item_image.dart';
+import 'package:ui/src/widgets/style.dart';
+
+/// Shows a dialog for quickly equipping items relevant to a skill.
+void showQuickEquipDialog(BuildContext context, Skill skill) {
+  showDialog<void>(
+    context: context,
+    builder: (_) => QuickEquipDialog(skill: skill),
+  );
+}
+
+/// A dialog that displays equippable items grouped by slot, with
+/// skill-relevant items shown first.
+class QuickEquipDialog extends StatelessWidget {
+  const QuickEquipDialog({required this.skill, super.key});
+
+  final Skill skill;
+
+  /// Slots to display, in the same order as EquipmentSlotsList.
+  static const List<EquipmentSlot> _displaySlots = [
+    EquipmentSlot.weapon,
+    EquipmentSlot.shield,
+    EquipmentSlot.helmet,
+    EquipmentSlot.platebody,
+    EquipmentSlot.platelegs,
+    EquipmentSlot.boots,
+    EquipmentSlot.gloves,
+    EquipmentSlot.cape,
+    EquipmentSlot.amulet,
+    EquipmentSlot.ring,
+    EquipmentSlot.quiver,
+    EquipmentSlot.passive,
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final state = context.state;
+    final equipment = state.equipment;
+    final skillId = skill.id;
+
+    // Gather equippable items from inventory, grouped by slot.
+    final itemsBySlot = <EquipmentSlot, List<Item>>{};
+    for (final stack in state.inventory.items) {
+      final item = stack.item;
+      if (!item.isEquippable || item.isSummonTablet) continue;
+      // Group under the first valid display slot.
+      for (final slot in _displaySlots) {
+        if (item.canEquipInSlot(slot)) {
+          itemsBySlot.putIfAbsent(slot, () => []).add(item);
+          break;
+        }
+      }
+    }
+
+    // Sort items within each slot: skill-relevant first, then
+    // alphabetically.
+    for (final items in itemsBySlot.values) {
+      items.sort((a, b) {
+        final aRelevant = a.hasModifiersForSkill(skillId);
+        final bRelevant = b.hasModifiersForSkill(skillId);
+        if (aRelevant != bRelevant) return aRelevant ? -1 : 1;
+        return a.name.compareTo(b.name);
+      });
+    }
+
+    // Only show slots that have items in inventory or are equipped.
+    final slotsToShow = _displaySlots.where((slot) {
+      return itemsBySlot.containsKey(slot) ||
+          equipment.gearInSlot(slot) != null;
+    }).toList();
+
+    return AlertDialog(
+      title: Text('Quick Equip — ${skill.name}'),
+      content: SizedBox(
+        width: 350,
+        child: slotsToShow.isEmpty
+            ? const Padding(
+                padding: EdgeInsets.all(16),
+                child: Text(
+                  'No equippable items in your bank.',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(color: Style.textColorSecondary),
+                ),
+              )
+            : ListView.builder(
+                shrinkWrap: true,
+                itemCount: slotsToShow.length,
+                itemBuilder: (context, index) {
+                  final slot = slotsToShow[index];
+                  return _SlotSection(
+                    slot: slot,
+                    skill: skill,
+                    equippedItem: equipment.gearInSlot(slot),
+                    bankItems: itemsBySlot[slot] ?? const [],
+                  );
+                },
+              ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+}
+
+/// A section in the quick equip dialog for a single slot.
+class _SlotSection extends StatelessWidget {
+  const _SlotSection({
+    required this.slot,
+    required this.skill,
+    required this.equippedItem,
+    required this.bankItems,
+  });
+
+  final EquipmentSlot slot;
+  final Skill skill;
+  final Item? equippedItem;
+  final List<Item> bankItems;
+
+  @override
+  Widget build(BuildContext context) {
+    final slotDef = context.state.registries.equipmentSlots[slot];
+    final slotName = slotDef?.emptyName ?? slot.jsonName;
+    final hasRelevantItems = bankItems.any(
+      (item) => item.hasModifiersForSkill(skill.id),
+    );
+
+    return ExpansionTile(
+      initiallyExpanded: hasRelevantItems,
+      leading: equippedItem != null
+          ? SizedBox(
+              width: 24,
+              height: 24,
+              child: ItemImage(item: equippedItem!, size: 24),
+            )
+          : const Icon(
+              Icons.circle_outlined,
+              size: 24,
+              color: Style.textColorSecondary,
+            ),
+      title: Text(slotName),
+      subtitle: equippedItem != null
+          ? Text(equippedItem!.name, style: const TextStyle(fontSize: 12))
+          : const Text(
+              'Empty',
+              style: TextStyle(fontSize: 12, color: Style.textColorSecondary),
+            ),
+      children: [
+        if (bankItems.isEmpty)
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text(
+              'No items in bank for this slot',
+              style: TextStyle(
+                fontSize: 12,
+                color: Style.textColorSecondary,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          )
+        else
+          for (final item in bankItems)
+            _EquippableItemTile(
+              item: item,
+              slot: slot,
+              skill: skill,
+              isEquipped: equippedItem?.id == item.id,
+            ),
+      ],
+    );
+  }
+}
+
+/// A tile for a single equippable item.
+class _EquippableItemTile extends StatelessWidget {
+  const _EquippableItemTile({
+    required this.item,
+    required this.slot,
+    required this.skill,
+    required this.isEquipped,
+  });
+
+  final Item item;
+  final EquipmentSlot slot;
+  final Skill skill;
+  final bool isEquipped;
+
+  @override
+  Widget build(BuildContext context) {
+    final state = context.state;
+    final unmetReqs = state.unmetEquipRequirements(item);
+    final isRelevant = item.hasModifiersForSkill(skill.id);
+
+    return ListTile(
+      dense: true,
+      leading: ItemImage(item: item, size: 24),
+      title: Text(
+        item.name,
+        style: TextStyle(fontWeight: isRelevant ? FontWeight.bold : null),
+      ),
+      subtitle: unmetReqs.isNotEmpty
+          ? Text(
+              'Requirements not met',
+              style: TextStyle(
+                fontSize: 12,
+                color: Style.unmetRequirementColor,
+              ),
+            )
+          : null,
+      selected: isEquipped,
+      trailing: isEquipped ? const Icon(Icons.check, size: 20) : null,
+      enabled: unmetReqs.isEmpty && !isEquipped,
+      onTap: unmetReqs.isEmpty && !isEquipped
+          ? () {
+              context.dispatch(EquipGearAction(item: item, slot: slot));
+            }
+          : null,
+    );
+  }
+}

--- a/ui/lib/src/widgets/simple_skill_page.dart
+++ b/ui/lib/src/widgets/simple_skill_page.dart
@@ -4,6 +4,7 @@ import 'package:ui/src/widgets/action_grid.dart';
 import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/game_scaffold.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
+import 'package:ui/src/widgets/skill_fab.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
 import 'package:ui/src/widgets/skill_progress.dart';
 
@@ -32,6 +33,7 @@ class SimpleSkillPage extends StatelessWidget {
     return GameScaffold(
       title: Text(skillName),
       actions: [SkillOverflowMenu(skill: skill)],
+      floatingActionButton: SkillFab(skill: skill),
       body: Column(
         children: [
           SkillProgress(xp: skillState.xp),

--- a/ui/lib/src/widgets/skill_fab.dart
+++ b/ui/lib/src/widgets/skill_fab.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:logic/logic.dart';
+import 'package:ui/src/widgets/equipment_slots.dart';
+import 'package:ui/src/widgets/expandable_fab.dart';
+import 'package:ui/src/widgets/quick_equip_dialog.dart';
+
+/// An expandable FAB for skill pages with Quick Equip and Equipment
+/// actions.
+class SkillFab extends StatelessWidget {
+  const SkillFab({required this.skill, super.key});
+
+  final Skill skill;
+
+  @override
+  Widget build(BuildContext context) {
+    return ExpandableFab(
+      actions: [
+        ExpandableFabAction(
+          icon: Icons.grid_view,
+          label: 'Equipment',
+          onPressed: () => showDialog<void>(
+            context: context,
+            builder: (_) => const EquipmentGridDialog(),
+          ),
+        ),
+        ExpandableFabAction(
+          icon: Icons.shield,
+          label: 'Quick Equip',
+          onPressed: () => showQuickEquipDialog(context, skill),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds an expandable multi-FAB to all skill pages (wrench icon in bottom-right)
- **Quick Equip** action: opens a dialog showing equippable bank items grouped by slot, with skill-relevant items (those with modifiers for the current skill) bolded and sorted first
- **Equipment** action: opens the existing equipment grid dialog for quick reference
- Adds `Item.hasModifiersForSkill()` method for determining item relevance to a skill

## Test plan
- [ ] Open any skill page and verify the FAB appears in the bottom-right
- [ ] Tap the FAB — verify it expands to show "Quick Equip" and "Equipment" buttons
- [ ] Tap "Equipment" — verify the existing equipment grid dialog opens
- [ ] Tap "Quick Equip" — verify the dialog shows bank items grouped by slot
- [ ] Verify skill-relevant items appear first and are bolded in each slot section
- [ ] Tap an item to equip it — verify it equips and the dialog updates
- [ ] Verify items with unmet requirements are disabled
- [ ] Run `dart test` in logic/ — all tests pass including new `items_skill_relevance_test.dart`