### PR TITLE
refactor: clean up async resume action and dialog

### DIFF
--- a/ui/lib/src/logic/game_loop.dart
+++ b/ui/lib/src/logic/game_loop.dart
@@ -49,6 +49,9 @@ class GameLoop {
   /// Used during app lifecycle transitions to prevent background execution.
   bool _isSuspended = false;
 
+  /// Whether the game loop is currently suspended.
+  bool get isSuspended => _isSuspended;
+
   // Drift detection fields (debug builds only)
   Tick? _lastPredictedTicks;
   DateTime? _lastDispatchTime;


### PR DESCRIPTION
## Summary
- Merge `ResumeProgressDialog` into `WelcomeBackDialog` as a single class with two constructors (`.loading` for async, default for immediate)
- Remove `ApplyResumeResultAction` — fold into `ResumeFromPauseAction.precomputed()` so there's one action for both sync and async resume paths
- Assert game loop is suspended during async resume processing
- Fix `_isProcessingResume` ordering to prevent duplicate dialog from `onChange` listener
- Add `listenables` to cspell dictionary

## Test plan
- [x] 4 new tests for `ResumeFromPauseAction` (sync, no-op, precomputed, merge with existing timeAway)
- [x] `dart analyze`, `dart format`, `cspell` all pass