### PR TITLE
fix: prevent duplicate welcome-back dialogs on repeated resume

### DIFF
--- a/ui/lib/src/screens/debug.dart
+++ b/ui/lib/src/screens/debug.dart
@@ -115,16 +115,12 @@ class DebugPage extends StatelessWidget {
     final timeAway = _createExampleTimeAway(context.state.registries);
 
     if (context.mounted) {
-      final result = ValueNotifier<TimeAway?>(timeAway);
+      final state = WelcomeBackState()..result.value = timeAway;
       await showDialog<void>(
         context: context,
-        builder: (context) => WelcomeBackDialog(
-          awayDuration: ValueNotifier(timeAway.duration),
-          progress: ValueNotifier(0),
-          result: result,
-        ),
+        builder: (context) => WelcomeBackDialog(state: state),
       );
-      result.dispose();
+      state.dispose();
     }
   }
 }
@@ -144,17 +140,12 @@ class _DebugActionsTab extends StatelessWidget {
     context.dispatch(action);
 
     if (context.mounted) {
-      final timeAway = action.timeAway;
-      final result = ValueNotifier<TimeAway?>(timeAway);
+      final state = WelcomeBackState()..result.value = action.timeAway;
       await showDialog<void>(
         context: context,
-        builder: (context) => WelcomeBackDialog(
-          awayDuration: ValueNotifier(timeAway.duration),
-          progress: ValueNotifier(0),
-          result: result,
-        ),
+        builder: (context) => WelcomeBackDialog(state: state),
       );
-      result.dispose();
+      state.dispose();
     }
   }
 


### PR DESCRIPTION
## Summary
- When the welcome-back dialog was already showing and the app went to background then returned, `_processResumeAsync` would unconditionally open a second dialog on top of the first.
- Fixed by promoting `progressNotifier`/`resultNotifier`/`awayDurationNotifier` to class-level fields on `_AppLifecycleManagerState`. The dialog always uses `ValueListenableBuilder`s on these shared notifiers, so it transitions in-place between loading and results states.
- Also fixes a subtler bug: short absences while dialog was showing would leave the dialog showing stale results.

## Test plan
- [ ] Background app while welcome-back dialog is showing, wait >5 min, foreground — should see progress bar in same dialog, then merged results
- [ ] Background app while welcome-back dialog is showing, return quickly — dialog should update with merged results in-place
- [ ] Normal short absence (no dialog showing) — dialog appears as before
- [ ] Normal long absence (no dialog showing) — loading → results as before
- [ ] Debug screen welcome-back preview still works