### PR TITLE
Add tooltip to item count badge cells

### DIFF
--- a/ui/lib/src/widgets/item_count_badge_cell.dart
+++ b/ui/lib/src/widgets/item_count_badge_cell.dart
@@ -39,13 +39,17 @@ class ItemCountBadgeCell extends StatelessWidget {
     // Icon size is roughly 60% of the inradius
     final iconSize = inradius * 0.6;
 
-    return CountBadgeCell(
-      inradius: inradius,
-      backgroundColor: Style.xpBadgeBackgroundColor,
-      borderColor: borderColor,
-      count: count,
-      child: Center(
-        child: ItemImage(item: item, size: iconSize),
+    return Tooltip(
+      message: item.name,
+      preferBelow: false,
+      child: CountBadgeCell(
+        inradius: inradius,
+        backgroundColor: Style.xpBadgeBackgroundColor,
+        borderColor: borderColor,
+        count: count,
+        child: Center(
+          child: ItemImage(item: item, size: iconSize),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Wraps `ItemCountBadgeCell` with a `Tooltip` showing the item name
- Makes it easy to identify items in production views (smithing, cooking, etc.) where only the icon and count are shown
- On desktop: hover to see item name. On mobile: long-press

## Test plan
- [ ] Open smithing view, hover over input/output item cells — tooltip shows item name
- [ ] On mobile, long-press an item cell — tooltip appears
- [ ] Verify tooltips appear in other production views (cooking, crafting, etc.)