### PR TITLE
Scroll to top when selecting a recipe in production skills

### DIFF
--- a/ui/lib/src/screens/crafting.dart
+++ b/ui/lib/src/screens/crafting.dart
@@ -20,6 +20,13 @@ class CraftingPage extends StatefulWidget {
 class _CraftingPageState extends State<CraftingPage> {
   CraftingAction? _selectedAction;
   final Set<MelvorId> _collapsedCategories = {};
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -58,6 +65,7 @@ class _CraftingPageState extends State<CraftingPage> {
           const MasteryPoolProgress(skill: skill),
           Expanded(
             child: SingleChildScrollView(
+              controller: _scrollController,
               padding: const EdgeInsets.all(16),
               child: Column(
                 children: [
@@ -86,6 +94,11 @@ class _CraftingPageState extends State<CraftingPage> {
                       setState(() {
                         _selectedAction = action;
                       });
+                      _scrollController.animateTo(
+                        0,
+                        duration: const Duration(milliseconds: 300),
+                        curve: Curves.easeOut,
+                      );
                     },
                     onToggleCategory: (category) {
                       setState(() {

--- a/ui/lib/src/screens/fletching.dart
+++ b/ui/lib/src/screens/fletching.dart
@@ -20,6 +20,13 @@ class FletchingPage extends StatefulWidget {
 class _FletchingPageState extends State<FletchingPage> {
   FletchingAction? _selectedAction;
   final Set<MelvorId> _collapsedCategories = {};
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -58,6 +65,7 @@ class _FletchingPageState extends State<FletchingPage> {
           const MasteryPoolProgress(skill: skill),
           Expanded(
             child: SingleChildScrollView(
+              controller: _scrollController,
               padding: const EdgeInsets.all(16),
               child: Column(
                 children: [
@@ -86,6 +94,11 @@ class _FletchingPageState extends State<FletchingPage> {
                       setState(() {
                         _selectedAction = action;
                       });
+                      _scrollController.animateTo(
+                        0,
+                        duration: const Duration(milliseconds: 300),
+                        curve: Curves.easeOut,
+                      );
                     },
                     onToggleCategory: (category) {
                       setState(() {

--- a/ui/lib/src/screens/herblore.dart
+++ b/ui/lib/src/screens/herblore.dart
@@ -20,6 +20,13 @@ class HerblorePage extends StatefulWidget {
 class _HerblorePageState extends State<HerblorePage> {
   HerbloreAction? _selectedAction;
   final Set<MelvorId> _collapsedCategories = {};
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -58,6 +65,7 @@ class _HerblorePageState extends State<HerblorePage> {
           const MasteryPoolProgress(skill: skill),
           Expanded(
             child: SingleChildScrollView(
+              controller: _scrollController,
               padding: const EdgeInsets.all(16),
               child: Column(
                 children: [
@@ -87,6 +95,11 @@ class _HerblorePageState extends State<HerblorePage> {
                       setState(() {
                         _selectedAction = action;
                       });
+                      _scrollController.animateTo(
+                        0,
+                        duration: const Duration(milliseconds: 300),
+                        curve: Curves.easeOut,
+                      );
                     },
                     onToggleCategory: (category) {
                       setState(() {

--- a/ui/lib/src/screens/smithing.dart
+++ b/ui/lib/src/screens/smithing.dart
@@ -20,6 +20,13 @@ class SmithingPage extends StatefulWidget {
 class _SmithingPageState extends State<SmithingPage> {
   SmithingAction? _selectedAction;
   final Set<MelvorId> _collapsedCategories = {};
+  final ScrollController _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -58,6 +65,7 @@ class _SmithingPageState extends State<SmithingPage> {
           const MasteryPoolProgress(skill: skill),
           Expanded(
             child: SingleChildScrollView(
+              controller: _scrollController,
               padding: const EdgeInsets.all(16),
               child: Column(
                 children: [
@@ -86,6 +94,11 @@ class _SmithingPageState extends State<SmithingPage> {
                       setState(() {
                         _selectedAction = action;
                       });
+                      _scrollController.animateTo(
+                        0,
+                        duration: const Duration(milliseconds: 300),
+                        curve: Curves.easeOut,
+                      );
                     },
                     onToggleCategory: (category) {
                       setState(() {


### PR DESCRIPTION
## Summary
- When selecting a recipe in Smithing, Crafting, Fletching, or Herblore, the page now smoothly scrolls back to the top
- This makes it easy to immediately start using the selected recipe without manually scrolling back up to the action display and start button

## Test plan
- [ ] Open Smithing, scroll down, tap a recipe — verify page scrolls to top
- [ ] Repeat for Crafting, Fletching, and Herblore
- [ ] Verify the scroll animation is smooth (300ms ease-out)