### PR TITLE
fix: claim mastery token slider with single token

### DIFF
--- a/ui/lib/src/screens/bank.dart
+++ b/ui/lib/src/screens/bank.dart
@@ -1308,8 +1308,8 @@ class _ClaimMasteryTokenSectionState extends State<_ClaimMasteryTokenSection> {
     final xpPerToken = state.masteryTokenXpPerClaim(skill);
     final claimable = state.claimableMasteryTokenCount(skill);
     final poolFull = currentPoolXp >= maxPoolXp;
-    final maxClaim = claimable.clamp(1, widget.maxCount);
-    final claimCountInt = _claimCount.round().clamp(1, maxClaim);
+    final maxClaim = claimable.clamp(0, widget.maxCount);
+    final claimCountInt = _claimCount.round().clamp(0, maxClaim);
     final totalXp = xpPerToken * claimCountInt;
 
     return Column(
@@ -1344,10 +1344,9 @@ class _ClaimMasteryTokenSectionState extends State<_ClaimMasteryTokenSection> {
         ),
         const SizedBox(height: 8),
         Slider(
-          value: _claimCount.clamp(1, widget.maxCount.toDouble()),
-          min: 1,
+          value: _claimCount,
           max: widget.maxCount > 0 ? widget.maxCount.toDouble() : 1.0,
-          divisions: widget.maxCount > 1 ? widget.maxCount - 1 : null,
+          divisions: widget.maxCount > 0 ? widget.maxCount : null,
           label: preciseNumberString(claimCountInt),
           onChanged: widget.maxCount > 0
               ? (value) {


### PR DESCRIPTION
## Summary
- The claim mastery token slider had `min: 1`, so with exactly 1 token the range was `[1, 1]` — a degenerate range that rendered the thumb at the far left
- Removed `min: 1` to match the sell slider pattern (`min: 0` default), so with 1 token the range is `[0, 1]` and the thumb correctly appears at the right

## Test plan
- [ ] Select a mastery token with count 1 in the bank and verify the claim slider shows at the right
- [ ] Verify selling an item with count 1 still shows slider at the right
- [ ] Verify claiming tokens still works correctly with larger counts