### PR TITLE
Show mastery XP % increase in spend dialog

### DIFF
--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -18,6 +18,18 @@ int playerTotalMasteryLevelForSkill(GlobalState state, Skill skill) {
   return total;
 }
 
+/// Returns the percentage increase in the global mastery XP multiplier
+/// from adding [levelsAdded] total mastery levels to a skill.
+double masteryXpGlobalPercentIncrease(
+  GlobalState state,
+  Skill skill,
+  int levelsAdded,
+) {
+  final currentTotal = playerTotalMasteryLevelForSkill(state, skill);
+  if (currentTotal == 0) return 0;
+  return levelsAdded / currentTotal * 100;
+}
+
 /// Returns the amount of mastery XP gained per action.
 int masteryXpPerAction(GlobalState state, SkillAction action) {
   return calculateMasteryXpPerAction(

--- a/logic/test/data/xp_test.dart
+++ b/logic/test/data/xp_test.dart
@@ -312,6 +312,44 @@ void main() {
     });
   });
 
+  group('masteryXpGlobalPercentIncrease', () {
+    test('returns percentage based on levels added vs current total', () {
+      final actions = testRegistries.actionsForSkill(Skill.firemaking);
+      // All actions at level 1: total = actionsCount × 1
+      final state = GlobalState.test(testRegistries);
+      final pct = masteryXpGlobalPercentIncrease(
+        state,
+        Skill.firemaking,
+        actions.length, // add one level per action
+      );
+      // Adding N levels when total is N means 100% increase.
+      expect(pct, closeTo(100.0, 0.01));
+    });
+
+    test('returns smaller percentage when total mastery is high', () {
+      final actions = testRegistries.actionsForSkill(Skill.firemaking);
+      // Set all actions to mastery level 50 (XP = startXpForLevel(50)).
+      final actionStates = {
+        for (final a in actions)
+          a.id: ActionState(masteryXp: startXpForLevel(50)),
+      };
+      final state = GlobalState.test(
+        testRegistries,
+        actionStates: actionStates,
+      );
+      final total = actions.length * 50;
+      final pct = masteryXpGlobalPercentIncrease(state, Skill.firemaking, 1);
+      // 1 / total × 100
+      expect(pct, closeTo(1 / total * 100, 0.01));
+    });
+
+    test('returns 0 when levelsAdded is 0', () {
+      final state = GlobalState.test(testRegistries);
+      final pct = masteryXpGlobalPercentIncrease(state, Skill.firemaking, 0);
+      expect(pct, 0.0);
+    });
+  });
+
   group('actionTimeForMastery', () {
     test('woodcutting uses actual action duration', () {
       final action = testRegistries.woodcuttingAction('Normal Tree');

--- a/ui/lib/src/widgets/spend_mastery_dialog.dart
+++ b/ui/lib/src/widgets/spend_mastery_dialog.dart
@@ -200,6 +200,12 @@ class _ActionMasteryRow extends StatelessWidget {
         ? progress.nextLevelXp! - masteryXp
         : 0;
 
+    final globalPctIncrease = masteryXpGlobalPercentIncrease(
+      state,
+      skill,
+      actualLevels,
+    ).toStringAsFixed(1);
+
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),
       child: IntrinsicHeight(
@@ -243,7 +249,8 @@ class _ActionMasteryRow extends StatelessWidget {
                         Text(
                           '${preciseNumberString(totalCost ?? xpToNextLevel)}'
                           ' XP for +$actualLevels'
-                          ' level${actualLevels == 1 ? '' : 's'}',
+                          ' level${actualLevels == 1 ? '' : 's'}'
+                          ' (+$globalPctIncrease%)',
                           style: Theme.of(context).textTheme.bodySmall
                               ?.copyWith(color: Style.textColorSecondary),
                         )
@@ -407,7 +414,17 @@ class _SpreadButton extends StatelessWidget {
                 title: Text(
                   option.floor > 0 ? 'Spend to ${option.floor}%' : 'Spend all',
                 ),
-                subtitle: Text('+${option.preview.levelsAdded} levels'),
+                subtitle: () {
+                  final pct = masteryXpGlobalPercentIncrease(
+                    state,
+                    skill,
+                    option.preview.levelsAdded,
+                  ).toStringAsFixed(1);
+                  return Text(
+                    '+${option.preview.levelsAdded}'
+                    ' levels (+$pct%)',
+                  );
+                }(),
                 onTap: () => Navigator.of(ctx).pop(option.floor),
               ),
           ],


### PR DESCRIPTION
## Summary
- Adds `masteryXpGlobalPercentIncrease()` helper that computes the percentage increase in the global mastery XP multiplier from adding levels
- Shows the % increase on each action row in the Spend Mastery dialog (e.g. "1,234 XP for +5 levels (+2.3%)")
- Shows the % increase on each option in the Distribute dialog (e.g. "+15 levels (+4.2%)")

This focuses on the global component of the mastery XP formula (`playerTotalMasteryLevel / totalMasteryForSkill`), ignoring per-action portions, so players can see the skill-wide benefit of spending.

## Test plan
- [x] `dart analyze --fatal-infos` passes
- [x] `dart test` passes in logic/ and ui/
- [ ] Manual: open Spend Mastery dialog, verify % shows on action rows and distribute options