### PR TITLE
Show only next locked item per category in production skills

### DIFF
--- a/ui/lib/src/widgets/categorized_action_list.dart
+++ b/ui/lib/src/widgets/categorized_action_list.dart
@@ -110,8 +110,7 @@ class CategorizedActionList<C, A extends SkillAction> extends StatelessWidget {
             children: [
               // Category header
               InkWell(
-                onTap:
-                    isFullyLocked ? null : () => onToggleCategory(category),
+                onTap: isFullyLocked ? null : () => onToggleCategory(category),
                 child: Container(
                   padding: const EdgeInsets.symmetric(
                     horizontal: 12,
@@ -137,10 +136,7 @@ class CategorizedActionList<C, A extends SkillAction> extends StatelessWidget {
                           color: Style.textColorSecondary,
                         ),
                       const SizedBox(width: 8),
-                      CachedImage(
-                        assetPath: categoryMedia(category),
-                        size: 24,
-                      ),
+                      CachedImage(assetPath: categoryMedia(category), size: 24),
                       const SizedBox(width: 8),
                       Text(
                         categoryName(category),
@@ -190,9 +186,7 @@ class CategorizedActionList<C, A extends SkillAction> extends StatelessWidget {
                           children: [
                             const Text(
                               'Unlocked at ',
-                              style: TextStyle(
-                                color: Style.textColorSecondary,
-                              ),
+                              style: TextStyle(color: Style.textColorSecondary),
                             ),
                             SkillImage(skill: skill!, size: 14),
                             Text(


### PR DESCRIPTION
## Summary
- In categorized production skills (Smithing, Crafting, Fletching, Herblore), only show one locked item per category — the next one to unlock — instead of all locked items
- Fully-locked categories display a dimmed header with a lock icon and the required level, with no expandable action list
- Partially-locked categories show all unlocked items plus one "Unlocked at Level X" card

## Test plan
- [ ] Open Smithing at a low level — verify each category shows at most one locked card
- [ ] Verify fully-locked categories show lock icon + "Level X" in header and are not expandable
- [ ] Verify partially-locked categories still show all unlocked items
- [ ] Check Crafting, Fletching, and Herblore behave the same way