### PR TITLE
fix: dismiss welcome back dialog when async resume has no changes

### DIFF
--- a/ui/lib/main.dart
+++ b/ui/lib/main.dart
@@ -380,6 +380,12 @@ class _AppLifecycleManagerState extends State<_AppLifecycleManager>
         'storeTimeAway=${storeTimeAway != null ? "present" : "null"}',
       );
       _welcomeBackState.result.value = storeTimeAway;
+      // If no changes occurred, dismiss the dialog since there's nothing
+      // to show. The pop triggers the .then() callback which resets
+      // _isDialogShowing and dispatches DismissWelcomeBackDialogAction.
+      if (storeTimeAway == null && _isDialogShowing) {
+        navigatorKey.currentState?.pop();
+      }
     } on Object catch (e, stackTrace) {
       logger.err('Async resume failed: $e\n$stackTrace');
       // Fall back to synchronous processing so the dialog can show results.


### PR DESCRIPTION
## Summary
- When returning to the app after a long absence with no active action, the async resume processed all ticks but found no changes, setting `storeTimeAway = null`
- Setting `_welcomeBackState.result.value = null` put the dialog back into the "Processing..." loading state with no OK button and `barrierDismissible: false`, permanently trapping the user
- Now pops the dialog via `navigatorKey.currentState?.pop()` when no changes occurred, which triggers the existing `.then()` cleanup

## Test plan
- [x] `flutter test` passes (162 tests)
- [ ] Background the app with no active action for >5 minutes, resume — dialog should not get stuck