### PR TITLE
fix: send dungeon rewards directly to inventory

### DIFF
--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -1286,7 +1286,7 @@ ForegroundResult _restartOrStop(
         if (dungeon != null) {
           for (final rewardId in dungeon.rewardItemIds) {
             final rewardItem = builder.registries.items.byId(rewardId);
-            builder.addToLoot(ItemStack(rewardItem, count: 1), isBones: false);
+            builder.addInventory(ItemStack(rewardItem, count: 1));
           }
           builder.rollDungeonPet(seqContext.sequenceId, random);
         }

--- a/logic/lib/src/state.dart
+++ b/logic/lib/src/state.dart
@@ -324,7 +324,6 @@ class GlobalState {
     this.stunned = const StunnedState.fresh(),
     this.attackStyle = AttackStyle.stab,
     this.readItems = const <MelvorId>{},
-    this.unlockedPets = const <MelvorId>{},
     this.agility = const AgilityState.empty(),
     this.cooking = const CookingState.empty(),
     this.summoning = const SummoningState.empty(),
@@ -397,7 +396,6 @@ class GlobalState {
     AstrologyState astrology = const AstrologyState.empty(),
     Map<Skill, MelvorId> selectedSkillActions = const {},
     Set<MelvorId> readItems = const {},
-    Set<MelvorId> unlockedPets = const {},
   }) {
     // Support both gp parameter (for existing tests) and currencies map
     final currenciesMap = currencies ?? (gp > 0 ? {Currency.gp: gp} : const {});
@@ -434,7 +432,6 @@ class GlobalState {
       astrology: astrology,
       selectedSkillActions: selectedSkillActions,
       readItems: readItems,
-      unlockedPets: unlockedPets,
     );
   }
 
@@ -475,11 +472,6 @@ class GlobalState {
           const {},
       unlockedPlots =
           (json['unlockedPlots'] as List<dynamic>?)
-              ?.map((e) => MelvorId.fromJson(e as String))
-              .toSet() ??
-          const {},
-      unlockedPets =
-          (json['unlockedPets'] as List<dynamic>?)
               ?.map((e) => MelvorId.fromJson(e as String))
               .toSet() ??
           const {},
@@ -709,7 +701,6 @@ class GlobalState {
         (key, value) => MapEntry(key.name, value.toJson()),
       ),
       'readItems': readItems.map((e) => e.toJson()).toList(),
-      'unlockedPets': unlockedPets.map((e) => e.toJson()).toList(),
     };
   }
 
@@ -872,9 +863,6 @@ class GlobalState {
   /// Set of item IDs that have been read (e.g., Message in a Bottle).
   /// Reading certain items unlocks content like secret fishing areas.
   final Set<MelvorId> readItems;
-
-  /// Set of pet IDs that the player has unlocked.
-  final Set<MelvorId> unlockedPets;
 
   /// The player's health state.
   final HealthState health;
@@ -3524,7 +3512,6 @@ class GlobalState {
     AstrologyState? astrology,
     Map<Skill, MelvorId>? selectedSkillActions,
     Set<MelvorId>? readItems,
-    Set<MelvorId>? unlockedPets,
   }) {
     return GlobalState(
       registries: registries,
@@ -3562,7 +3549,6 @@ class GlobalState {
       astrology: astrology ?? this.astrology,
       selectedSkillActions: selectedSkillActions ?? this.selectedSkillActions,
       readItems: readItems ?? this.readItems,
-      unlockedPets: unlockedPets ?? this.unlockedPets,
     );
   }
 

--- a/logic/test/consume_ticks_test.dart
+++ b/logic/test/consume_ticks_test.dart
@@ -2167,13 +2167,10 @@ void main() {
       expect(bonesInLoot, 0, reason: 'dropBones is false');
 
       // Dungeon monsters should not drop their personal loot tables.
-      // Only the dungeon reward items (Egg_Chest) should appear in loot.
+      // Dungeon reward items (Egg_Chest) go straight to inventory.
       final eggChest = testItems.byName('Egg Chest');
-      final rewardCount = state.loot.stacks
-          .where((s) => s.item.id == eggChest.id)
-          .fold(0, (sum, s) => sum + s.count);
       expect(
-        rewardCount,
+        state.inventory.countOfItem(eggChest),
         completions,
         reason: 'Should get one Egg Chest per dungeon completion',
       );


### PR DESCRIPTION
## Summary
- Dungeon reward items (e.g. Egg Chest) now go directly to the player's inventory on completion instead of sitting in the loot container
- Also fixes a pre-existing duplicate `unlockedPets` field in `GlobalState` that was causing compilation errors

## Test plan
- [x] Updated existing dungeon reward test to verify items land in inventory
- [x] All 2229 logic tests pass