### PR TITLE
fix: remove duplicate food display in welcome back dialog

### DIFF
--- a/ui/lib/src/widgets/welcome_back_dialog.dart
+++ b/ui/lib/src/widgets/welcome_back_dialog.dart
@@ -261,32 +261,37 @@ class WelcomeBackDialog extends StatelessWidget {
             ],
 
             // 5. Items gained, by type (with per hour estimate)
+            // Exclude items already shown in foodEaten (section 9) to
+            // avoid duplicate rows.
             if (changes.inventoryChanges.isNotEmpty) ...[
               const SizedBox(height: 8),
-              ...changes.inventoryChanges.entries.map((entry) {
-                final itemId = entry.key;
-                final itemCount = entry.value;
-                final item = registries.items.byId(itemId);
-                final gainedPerHour = timeAway.itemsGainedPerHour[itemId];
-                final consumedPerHour = timeAway.itemsConsumedPerHour[itemId];
+              ...changes.inventoryChanges.entries
+                  .where((e) => !changes.foodEaten.counts.containsKey(e.key))
+                  .map((entry) {
+                    final itemId = entry.key;
+                    final itemCount = entry.value;
+                    final item = registries.items.byId(itemId);
+                    final gainedPerHour = timeAway.itemsGainedPerHour[itemId];
+                    final consumedPerHour =
+                        timeAway.itemsConsumedPerHour[itemId];
 
-                final String prediction;
-                if (itemCount > 0 && gainedPerHour != null) {
-                  prediction =
-                      ' (${approximateCountString(gainedPerHour.round())}/hr)';
-                } else if (itemCount < 0 && consumedPerHour != null) {
-                  prediction =
-                      ' (${approximateCountString(consumedPerHour.round())}/hr)';
-                } else {
-                  prediction = '';
-                }
+                    final String prediction;
+                    if (itemCount > 0 && gainedPerHour != null) {
+                      prediction =
+                          ' (${approximateCountString(gainedPerHour.round())}/hr)';
+                    } else if (itemCount < 0 && consumedPerHour != null) {
+                      prediction =
+                          ' (${approximateCountString(consumedPerHour.round())}/hr)';
+                    } else {
+                      prediction = '';
+                    }
 
-                return ItemChangeRow(
-                  item: item,
-                  count: itemCount,
-                  suffix: prediction,
-                );
-              }),
+                    return ItemChangeRow(
+                      item: item,
+                      count: itemCount,
+                      suffix: prediction,
+                    );
+                  }),
             ],
 
             // 6. Currencies earned (by type)


### PR DESCRIPTION
## Summary
- Food consumption was showing twice in the welcome back dialog: once in the inventory changes section (without per-hour rate) and again in the food eaten section (with per-hour rate)
- Root cause: `tryAutoEat()` records food in both `inventoryChanges` (via `_changes.removing()`) and `foodEaten` (via `_changes.recordingFoodEaten()`)
- Fix: filter `foodEaten` item IDs out of the `inventoryChanges` display so food only appears in its dedicated section

## Test plan
- [ ] Fight a combat encounter that triggers auto-eat, then close and reopen the app to see the welcome back dialog
- [ ] Verify food appears only once (in the food eaten section with per-hour rate)
- [ ] Verify other inventory changes (loot drops, resources) still display correctly