### PR TITLE
fix: handle edge cases in food deduplication for welcome back dialog

### DIFF
--- a/ui/lib/src/widgets/welcome_back_dialog.dart
+++ b/ui/lib/src/widgets/welcome_back_dialog.dart
@@ -261,37 +261,41 @@ class WelcomeBackDialog extends StatelessWidget {
             ],
 
             // 5. Items gained, by type (with per hour estimate)
-            // Exclude items already shown in foodEaten (section 9) to
-            // avoid duplicate rows.
+            // Subtract foodEaten from inventoryChanges so food consumption
+            // only appears in its dedicated section (section 9). If there
+            // are other gains/losses for the same item, those still show.
             if (changes.inventoryChanges.isNotEmpty) ...[
               const SizedBox(height: 8),
-              ...changes.inventoryChanges.entries
-                  .where((e) => !changes.foodEaten.counts.containsKey(e.key))
-                  .map((entry) {
-                    final itemId = entry.key;
-                    final itemCount = entry.value;
-                    final item = registries.items.byId(itemId);
-                    final gainedPerHour = timeAway.itemsGainedPerHour[itemId];
-                    final consumedPerHour =
-                        timeAway.itemsConsumedPerHour[itemId];
+              ...changes.inventoryChanges.entries.expand((entry) {
+                final itemId = entry.key;
+                // Subtract food eaten so it only shows in section 9.
+                final foodCount = changes.foodEaten.counts[itemId] ?? 0;
+                final itemCount = entry.value + foodCount;
+                if (itemCount == 0) return <Widget>[];
 
-                    final String prediction;
-                    if (itemCount > 0 && gainedPerHour != null) {
-                      prediction =
-                          ' (${approximateCountString(gainedPerHour.round())}/hr)';
-                    } else if (itemCount < 0 && consumedPerHour != null) {
-                      prediction =
-                          ' (${approximateCountString(consumedPerHour.round())}/hr)';
-                    } else {
-                      prediction = '';
-                    }
+                final item = registries.items.byId(itemId);
+                final gainedPerHour = timeAway.itemsGainedPerHour[itemId];
+                final consumedPerHour = timeAway.itemsConsumedPerHour[itemId];
 
-                    return ItemChangeRow(
-                      item: item,
-                      count: itemCount,
-                      suffix: prediction,
-                    );
-                  }),
+                final String prediction;
+                if (itemCount > 0 && gainedPerHour != null) {
+                  prediction =
+                      ' (${approximateCountString(gainedPerHour.round())}/hr)';
+                } else if (itemCount < 0 && consumedPerHour != null) {
+                  prediction =
+                      ' (${approximateCountString(consumedPerHour.round())}/hr)';
+                } else {
+                  prediction = '';
+                }
+
+                return [
+                  ItemChangeRow(
+                    item: item,
+                    count: itemCount,
+                    suffix: prediction,
+                  ),
+                ];
+              }),
             ],
 
             // 6. Currencies earned (by type)


### PR DESCRIPTION
## Summary
- Follow-up to #163 which filtered food items entirely from inventory changes
- The previous approach would hide non-food gains/losses of the same item (e.g. looting shrimp while also eating shrimp)
- Now subtracts the `foodEaten` count from `inventoryChanges` and only hides items where the adjusted count is zero
- Example: ate 17 shrimp, looted 5 → food section shows "-17 shrimp", inventory section shows "+5 shrimp"

## Test plan
- [ ] Fight a combat encounter that triggers auto-eat, close/reopen app, verify food appears only once
- [ ] Verify other inventory changes for the same food item (if any) still display correctly