### PR TITLE
feat: add pet modifiers and celebratory dialog

### DIFF
--- a/logic/lib/src/data/pets.dart
+++ b/logic/lib/src/data/pets.dart
@@ -1,4 +1,5 @@
 import 'package:logic/src/data/melvor_id.dart';
+import 'package:logic/src/types/modifier.dart';
 import 'package:meta/meta.dart';
 
 /// A pet that can be found/unlocked during gameplay.
@@ -9,9 +10,11 @@ class Pet {
     required this.name,
     required this.media,
     required this.ignoreCompletion,
+    required this.modifiers,
   });
 
   factory Pet.fromJson(Map<String, dynamic> json, {required String namespace}) {
+    final modifiersJson = json['modifiers'] as Map<String, dynamic>? ?? {};
     return Pet(
       id: MelvorId.fromJsonWithNamespace(
         json['id'] as String,
@@ -20,6 +23,7 @@ class Pet {
       name: json['name'] as String,
       media: json['media'] as String?,
       ignoreCompletion: json['ignoreCompletion'] as bool? ?? false,
+      modifiers: ModifierDataSet.fromJson(modifiersJson, namespace: namespace),
     );
   }
 
@@ -27,6 +31,9 @@ class Pet {
   final String name;
   final String? media;
   final bool ignoreCompletion;
+
+  /// Modifiers provided when this pet is unlocked.
+  final ModifierDataSet modifiers;
 }
 
 /// Registry of all pets in the game.

--- a/logic/lib/src/state.dart
+++ b/logic/lib/src/state.dart
@@ -1121,6 +1121,7 @@ class GlobalState {
       activeSynergy: applicableSynergy,
       agility: agility,
       astrology: astrology,
+      unlockedPetIds: unlockedPets,
       currentActionId: action.id,
       conditionContext: _withActivePotions(conditionContext),
     );
@@ -1188,6 +1189,7 @@ class GlobalState {
       activeSynergy: applicableSynergy,
       agility: agility,
       astrology: astrology,
+      unlockedPetIds: unlockedPets,
       combatTypeSkills: attackStyle.combatType.skills,
       conditionContext: _withActivePotions(conditionContext),
       slayerAreaEffect: areaEffect,
@@ -1218,6 +1220,7 @@ class GlobalState {
       activeSynergy: _getActiveSynergy(),
       agility: agility,
       astrology: astrology,
+      unlockedPetIds: unlockedPets,
       conditionContext: _withActivePotions(conditionContext),
     );
   }

--- a/logic/lib/src/types/modifier_provider.dart
+++ b/logic/lib/src/types/modifier_provider.dart
@@ -209,6 +209,7 @@ class ModifierProvider with ModifierAccessors {
     required this.skillStateGetter,
     required this.agility,
     required this.astrology,
+    this.unlockedPetIds = const {},
     this.combatTypeSkills,
     this.currentActionId,
     this.conditionContext = ConditionContext.empty,
@@ -234,6 +235,9 @@ class ModifierProvider with ModifierAccessors {
   /// Returns the SkillState for a given skill.
   /// Used to look up mastery pool XP for mastery pool checkpoint bonuses.
   final SkillState Function(Skill) skillStateGetter;
+
+  /// IDs of unlocked pets whose modifiers should be included.
+  final Set<MelvorId> unlockedPetIds;
 
   /// For combat: the set of combat skills being used (attack, strength, etc.)
   /// Used to filter summoning familiar relevance.
@@ -479,6 +483,20 @@ class ModifierProvider with ModifierAccessors {
         for (final entry in mod.entries) {
           if (scope.matches(entry.scope)) {
             total += entry.value;
+          }
+        }
+      }
+    }
+
+    // --- Pet modifiers ---
+    // Unlocked pets provide passive modifiers.
+    for (final petId in unlockedPetIds) {
+      final pet = registries.pets.byId(petId);
+      for (final mod in pet.modifiers.modifiers) {
+        if (mod.name != name) continue;
+        for (final modEntry in mod.entries) {
+          if (scope.matches(modEntry.scope)) {
+            total += modEntry.value;
           }
         }
       }

--- a/ui/lib/src/logic/redux_actions.dart
+++ b/ui/lib/src/logic/redux_actions.dart
@@ -51,6 +51,9 @@ class UpdateActivityProgressAction extends ReduxAction<GlobalState> {
         toastService.showDeath(changes.lostOnDeath);
       }
 
+      // Show pet found dialog for each newly unlocked pet
+      changes.petsUnlocked.forEach(toastService.showPetUnlocked);
+
       return newState;
     }
   }

--- a/ui/lib/src/screens/pets_log.dart
+++ b/ui/lib/src/screens/pets_log.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:logic/logic.dart';
 import 'package:ui/src/logic/redux_actions.dart';
 import 'package:ui/src/widgets/cached_image.dart';
+import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/game_scaffold.dart';
+import 'package:ui/src/widgets/pet_found_dialog.dart';
 import 'package:ui/src/widgets/style.dart';
 
 class PetsLogPage extends StatelessWidget {
@@ -93,22 +95,36 @@ class _PetCell extends StatelessWidget {
   Widget build(BuildContext context) {
     return Tooltip(
       message: found ? pet.name : '???',
-      child: Container(
-        width: _size,
-        height: _size,
-        decoration: BoxDecoration(
-          color: Style.cellBackgroundColor,
-          borderRadius: BorderRadius.circular(4),
-        ),
-        child: found
-            ? CachedImage(assetPath: pet.media, size: _size)
-            : const Center(
-                child: Icon(
-                  Icons.help_outline,
-                  size: _size * 0.6,
-                  color: Style.iconColorDefault,
+      child: GestureDetector(
+        onTap: found
+            ? () {
+                final registries = context.state.registries;
+                showDialog<void>(
+                  context: context,
+                  builder: (_) => PetFoundDialog(
+                    pet: pet,
+                    modifierMetadata: registries.modifierMetadata,
+                  ),
+                );
+              }
+            : null,
+        child: Container(
+          width: _size,
+          height: _size,
+          decoration: BoxDecoration(
+            color: Style.cellBackgroundColor,
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: found
+              ? CachedImage(assetPath: pet.media, size: _size)
+              : const Center(
+                  child: Icon(
+                    Icons.help_outline,
+                    size: _size * 0.6,
+                    color: Style.iconColorDefault,
+                  ),
                 ),
-              ),
+        ),
       ),
     );
   }

--- a/ui/lib/src/services/toast_service.dart
+++ b/ui/lib/src/services/toast_service.dart
@@ -13,6 +13,9 @@ class ToastService {
   final _deathController = StreamController<Counts<MelvorId>>.broadcast();
   Stream<Counts<MelvorId>> get deathStream => _deathController.stream;
 
+  final _petUnlockedController = StreamController<MelvorId>.broadcast();
+  Stream<MelvorId> get petUnlockedStream => _petUnlockedController.stream;
+
   void showToast(Changes changes) {
     _toastController.add(changes);
   }
@@ -23,6 +26,10 @@ class ToastService {
 
   void showDeath(Counts<MelvorId> lostOnDeath) {
     _deathController.add(lostOnDeath);
+  }
+
+  void showPetUnlocked(MelvorId petId) {
+    _petUnlockedController.add(petId);
   }
 }
 

--- a/ui/lib/src/widgets/pet_found_dialog.dart
+++ b/ui/lib/src/widgets/pet_found_dialog.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:logic/logic.dart';
+import 'package:ui/src/widgets/cached_image.dart';
+import 'package:ui/src/widgets/style.dart';
+
+/// A celebratory dialog shown when the player finds a pet.
+class PetFoundDialog extends StatelessWidget {
+  const PetFoundDialog({
+    required this.pet,
+    required this.modifierMetadata,
+    super.key,
+  });
+
+  final Pet pet;
+  final ModifierMetadataRegistry modifierMetadata;
+
+  @override
+  Widget build(BuildContext context) {
+    final descriptions = _formatModifiers(pet, modifierMetadata);
+
+    return AlertDialog(
+      title: Column(
+        children: [
+          CachedImage(assetPath: pet.media, size: 80),
+          const SizedBox(height: 12),
+          const Text('Pet Found!'),
+        ],
+      ),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              pet.name,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            if (descriptions.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              for (final desc in descriptions)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Text(
+                    desc,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: Style.textColorSuccess,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+            ],
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+
+  List<String> _formatModifiers(Pet pet, ModifierMetadataRegistry registry) {
+    final descriptions = <String>[];
+    for (final mod in pet.modifiers.modifiers) {
+      for (final entry in mod.entries) {
+        String? skillName;
+        String? currencyName;
+        final scope = entry.scope;
+        if (scope != null) {
+          if (scope.skillId != null) {
+            skillName = Skill.fromId(scope.skillId!).name;
+          }
+          if (scope.currencyId != null) {
+            currencyName = Currency.fromId(scope.currencyId!).name;
+          }
+        }
+        descriptions.add(
+          registry.formatDescription(
+            name: mod.name,
+            value: entry.value,
+            skillName: skillName,
+            currencyName: currencyName,
+          ),
+        );
+      }
+    }
+    return descriptions;
+  }
+}

--- a/ui/lib/src/widgets/toast_overlay.dart
+++ b/ui/lib/src/widgets/toast_overlay.dart
@@ -6,6 +6,7 @@ import 'package:ui/src/services/toast_service.dart';
 import 'package:ui/src/widgets/cached_image.dart';
 import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/item_image.dart';
+import 'package:ui/src/widgets/pet_found_dialog.dart';
 import 'package:ui/src/widgets/router.dart' show navigatorKey;
 import 'package:ui/src/widgets/skill_image.dart';
 import 'package:ui/src/widgets/style.dart';
@@ -31,7 +32,10 @@ class _ToastOverlayState extends State<ToastOverlay>
   StreamSubscription<Changes>? _toastSubscription;
   StreamSubscription<String>? _errorSubscription;
   StreamSubscription<Counts<MelvorId>>? _deathSubscription;
+  StreamSubscription<MelvorId>? _petSubscription;
   bool _isDeathDialogShowing = false;
+  bool _isPetDialogShowing = false;
+  final _petQueue = <MelvorId>[];
 
   @override
   void initState() {
@@ -45,6 +49,9 @@ class _ToastOverlayState extends State<ToastOverlay>
     _toastSubscription = widget.service.toastStream.listen(_showToast);
     _errorSubscription = widget.service.errorStream.listen(_showError);
     _deathSubscription = widget.service.deathStream.listen(_showDeathDialog);
+    _petSubscription = widget.service.petUnlockedStream.listen(
+      _showPetFoundDialog,
+    );
   }
 
   @override
@@ -52,6 +59,7 @@ class _ToastOverlayState extends State<ToastOverlay>
     _toastSubscription?.cancel();
     _errorSubscription?.cancel();
     _deathSubscription?.cancel();
+    _petSubscription?.cancel();
     _controller.dispose();
     _hideTimer?.cancel();
     super.dispose();
@@ -74,6 +82,35 @@ class _ToastOverlayState extends State<ToastOverlay>
     ).then((_) {
       if (mounted) {
         _isDeathDialogShowing = false;
+      }
+    });
+  }
+
+  void _showPetFoundDialog(MelvorId petId) {
+    _petQueue.add(petId);
+    _showNextPetDialog();
+  }
+
+  void _showNextPetDialog() {
+    if (_isPetDialogShowing || _petQueue.isEmpty) return;
+    final navContext = navigatorKey.currentContext;
+    if (navContext == null) return;
+    _isPetDialogShowing = true;
+
+    final petId = _petQueue.removeAt(0);
+    final registries = navContext.state.registries;
+    final pet = registries.pets.byId(petId);
+
+    showDialog<void>(
+      context: navContext,
+      builder: (context) => PetFoundDialog(
+        pet: pet,
+        modifierMetadata: registries.modifierMetadata,
+      ),
+    ).then((_) {
+      if (mounted) {
+        _isPetDialogShowing = false;
+        _showNextPetDialog();
       }
     });
   }


### PR DESCRIPTION
## Summary
- Parse pet modifiers from game JSON data and include them in the modifier calculation pipeline (all unlocked pets contribute their modifiers passively)
- Show a celebratory dialog when a pet is found, displaying the pet image, name, and modifier descriptions
- Make found pets tappable in the Pets Log to view their details and modifiers

## Test plan
- [x] `dart test -r failures-only` (logic) — 2229 tests pass
- [x] `flutter test -r failures-only` (ui) — 162 tests pass
- [x] `dart analyze --fatal-infos` on lib directories — no issues
- [x] `dart format .` — clean
- [x] `npx cspell` — clean
- [ ] Manual: complete a dungeon with a pet drop and verify the celebratory dialog appears
- [ ] Manual: open Pets Log, tap a found pet, verify modifier details show
- [ ] Manual: verify pet modifiers affect gameplay (e.g., Snek gives +50% GP from Thieving)