### PR TITLE
Improve item detail drawer for openable items

### DIFF
--- a/ui/lib/src/screens/bank.dart
+++ b/ui/lib/src/screens/bank.dart
@@ -581,10 +581,7 @@ class _ItemDetailsContentState extends State<_ItemDetailsContent> {
             const SizedBox(height: 16),
             Row(
               children: [
-                Text(
-                  '0',
-                  style: Theme.of(context).textTheme.bodySmall,
-                ),
+                Text('0', style: Theme.of(context).textTheme.bodySmall),
                 Expanded(
                   child: Slider(
                     value: _sellCount,


### PR DESCRIPTION
## Summary
- Replace "Open to receive a random drop" text with a "View Possible Contents" button that opens a dialog listing all drop table entries (e.g., "Up to 5x Whale")
- Move Open Item section above Sell so Sell is always the bottommost section
- Replace sell quantity label with 0/max markers on the slider ends

## Test plan
- [ ] Open an openable item's detail drawer, verify "View Possible Contents" button appears
- [ ] Tap button, verify dialog lists all possible drops with correct quantities
- [ ] Verify Open section appears above Sell section
- [ ] Verify sell slider shows 0 on left and total count on right