### PR TITLE
perf: increase resume chunk size for faster long-absence processing

### DIFF
--- a/ui/lib/main.dart
+++ b/ui/lib/main.dart
@@ -242,7 +242,8 @@ class _AppLifecycleManagerState extends State<_AppLifecycleManager>
   static const _asyncResumeThreshold = 3000;
 
   /// Number of ticks to process per chunk during async resume.
-  static const _resumeChunkSize = 1000;
+  /// 36000 ticks = 1 hour of game time.
+  static const _resumeChunkSize = 36000;
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState lifecycle) {


### PR DESCRIPTION
## Summary
- Increased `_resumeChunkSize` from 1000 to 36000 ticks (1.7 min → 1 hour of game time per chunk)
- A 10-hour absence now processes in ~10 chunks instead of 360, reducing overhead from yielding, `TimeAway` merging, and repeated function calls
- Especially impactful on web where each yield is more expensive

## Test plan
- [ ] Resume after a long absence (>5 min) and verify the welcome back dialog loads faster
- [ ] Verify the progress bar still updates during resume
- [ ] Test on web build specifically