### PR TITLE
feat: add thieving NPC drops dialog

### DIFF
--- a/ui/lib/src/screens/thieving.dart
+++ b/ui/lib/src/screens/thieving.dart
@@ -11,6 +11,7 @@ import 'package:ui/src/widgets/skill_image.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
 import 'package:ui/src/widgets/skill_progress.dart';
 import 'package:ui/src/widgets/style.dart';
+import 'package:ui/src/widgets/thieving_drops_dialog.dart';
 import 'package:ui/src/widgets/tweened_progress_indicator.dart';
 import 'package:ui/src/widgets/xp_badges_row.dart';
 
@@ -259,12 +260,28 @@ class _SelectedActionDisplay extends StatelessWidget {
           _ThievingProgressBar(action: action),
           const SizedBox(height: 16),
 
-          ElevatedButton(
-            onPressed: canToggle ? onStart : null,
-            style: ElevatedButton.styleFrom(
-              backgroundColor: isActive ? Style.activeColor : null,
-            ),
-            child: Text(isActive ? 'Stop' : 'Pickpocket'),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () => showDialog<void>(
+                    context: context,
+                    builder: (_) => ThievingDropsDialog(action: action),
+                  ),
+                  child: const Text('Drops'),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: canToggle ? onStart : null,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: isActive ? Style.activeColor : null,
+                  ),
+                  child: Text(isActive ? 'Stop' : 'Pickpocket'),
+                ),
+              ),
+            ],
           ),
         ],
       ),

--- a/ui/lib/src/widgets/thieving_drops_dialog.dart
+++ b/ui/lib/src/widgets/thieving_drops_dialog.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:logic/logic.dart';
+import 'package:ui/src/widgets/cached_image.dart';
+import 'package:ui/src/widgets/context_extensions.dart';
+import 'package:ui/src/widgets/item_image.dart';
+import 'package:ui/src/widgets/style.dart';
+
+/// A dialog that displays the drops for a thieving NPC.
+class ThievingDropsDialog extends StatelessWidget {
+  const ThievingDropsDialog({required this.action, super.key});
+
+  final ThievingAction action;
+
+  @override
+  Widget build(BuildContext context) {
+    final items = context.state.registries.items;
+
+    return AlertDialog(
+      title: Row(
+        children: [
+          if (action.media != null) ...[
+            CachedImage(assetPath: action.media),
+            const SizedBox(width: 8),
+          ],
+          Expanded(child: Text(action.name)),
+        ],
+      ),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // GP section
+            const Text('GP:', style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            _DropRow(
+              prefix: '1 - ${action.maxGold}',
+              icon: CachedImage(assetPath: Currency.gp.assetPath, size: 20),
+              name: Currency.gp.abbreviation,
+            ),
+            const SizedBox(height: 16),
+
+            // Common Drops section
+            const Text(
+              'Common Drops:',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            if (action.dropTable != null)
+              _buildDropTable(items, action.dropTable!)
+            else
+              const Text(
+                'None',
+                style: TextStyle(color: Style.textColorSecondary),
+              ),
+            const SizedBox(height: 16),
+
+            // Rare Drops section
+            const Text(
+              'Rare Drops:',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            if (action.uniqueDrop != null)
+              _DropRow(
+                prefix: '${action.uniqueDrop!.count} x',
+                icon: ItemImage(
+                  item: items.byId(action.uniqueDrop!.itemId),
+                  size: 20,
+                ),
+                name: items.byId(action.uniqueDrop!.itemId).name,
+              )
+            else
+              const Text(
+                'None',
+                style: TextStyle(color: Style.textColorSecondary),
+              ),
+            const SizedBox(height: 16),
+
+            // Area Unique Drops section
+            const Text(
+              'Area Unique Drops:',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            if (action.area.uniqueDrops.isNotEmpty)
+              ...action.area.uniqueDrops.map(
+                (drop) => _DropRow(
+                  prefix: '${drop.count} x',
+                  icon: ItemImage(item: items.byId(drop.itemId), size: 20),
+                  name: items.byId(drop.itemId).name,
+                ),
+              )
+            else
+              const Text(
+                'None',
+                style: TextStyle(color: Style.textColorSecondary),
+              ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDropTable(ItemRegistry items, Droppable dropTable) {
+    if (dropTable is! DropChance) {
+      return const Text(
+        'Unknown loot format',
+        style: TextStyle(color: Style.textColorSecondary),
+      );
+    }
+
+    final innerTable = dropTable.child;
+    if (innerTable is! DropTable) {
+      return const Text(
+        'Unknown loot format',
+        style: TextStyle(color: Style.textColorSecondary),
+      );
+    }
+
+    // Sort entries by weight descending (most common first)
+    final sortedEntries = List<DropTableEntry>.from(innerTable.entries)
+      ..sort((a, b) => b.weight.compareTo(a.weight));
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: sortedEntries.map((entry) {
+        final item = items.byId(entry.itemID);
+        return _DropRow(
+          prefix: _formatQuantity(entry.minQuantity, entry.maxQuantity),
+          icon: ItemImage(item: item, size: 20),
+          name: item.name,
+        );
+      }).toList(),
+    );
+  }
+
+  String _formatQuantity(int min, int max) {
+    if (min == max) {
+      return '$min x';
+    }
+    return '$min - $max x';
+  }
+}
+
+class _DropRow extends StatelessWidget {
+  const _DropRow({
+    required this.prefix,
+    required this.icon,
+    required this.name,
+  });
+
+  final String prefix;
+  final Widget icon;
+  final String name;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 8, bottom: 4),
+      child: Row(
+        children: [
+          Text(prefix),
+          const SizedBox(width: 4),
+          icon,
+          const SizedBox(width: 4),
+          Expanded(child: Text(name)),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add `ThievingDropsDialog` widget showing GP range, common drops (sorted by weight), rare drops, and area unique drops for thieving NPCs
- Add "Drops" button next to the Pickpocket/Stop button in the thieving NPC detail view
- Follows the existing `MonsterDropsDialog` pattern from combat

## Test plan
- [ ] Open thieving page, select an NPC, tap "Drops" button
- [ ] Verify GP range shows "1 - {maxGold}"
- [ ] Verify common drops are listed sorted by likelihood
- [ ] Verify rare drops and area unique drops sections appear correctly
- [ ] Verify dialog closes with "Close" button
- [ ] `flutter test` passes (162 tests)
- [ ] `dart analyze` clean on changed files