### PR TITLE
feat: add multi-tree woodcutting support

### DIFF
--- a/logic/lib/src/activity/active_activity.dart
+++ b/logic/lib/src/activity/active_activity.dart
@@ -83,6 +83,7 @@ class SkillActivity extends ActiveActivity {
     required super.progressTicks,
     required super.totalTicks,
     this.selectedRecipeIndex,
+    this.secondaryActionId,
   });
 
   factory SkillActivity.fromJson(Map<String, dynamic> json) {
@@ -92,6 +93,9 @@ class SkillActivity extends ActiveActivity {
       progressTicks: json['progressTicks'] as int,
       totalTicks: json['totalTicks'] as int,
       selectedRecipeIndex: json['selectedRecipeIndex'] as int?,
+      secondaryActionId: json['secondaryActionId'] != null
+          ? MelvorId.fromJson(json['secondaryActionId'] as String)
+          : null,
     );
   }
 
@@ -105,6 +109,30 @@ class SkillActivity extends ActiveActivity {
   /// Null if the action has no alternatives or the default is selected.
   final int? selectedRecipeIndex;
 
+  /// Secondary action for multi-tree woodcutting.
+  /// When set, both the primary and secondary trees are cut each cycle.
+  /// The primary tree (actionId) is the slower tree that sets the timer.
+  /// The secondary tree produces logs scaled by M_Action multiplier.
+  final MelvorId? secondaryActionId;
+
+  SkillActivity copyWith({
+    Skill? skill,
+    MelvorId? actionId,
+    Tick? progressTicks,
+    Tick? totalTicks,
+    int? selectedRecipeIndex,
+    MelvorId? secondaryActionId,
+  }) {
+    return SkillActivity(
+      skill: skill ?? this.skill,
+      actionId: actionId ?? this.actionId,
+      progressTicks: progressTicks ?? this.progressTicks,
+      totalTicks: totalTicks ?? this.totalTicks,
+      selectedRecipeIndex: selectedRecipeIndex ?? this.selectedRecipeIndex,
+      secondaryActionId: secondaryActionId ?? this.secondaryActionId,
+    );
+  }
+
   @override
   SkillActivity withProgress({required Tick progressTicks}) {
     return SkillActivity(
@@ -113,6 +141,7 @@ class SkillActivity extends ActiveActivity {
       progressTicks: progressTicks,
       totalTicks: totalTicks,
       selectedRecipeIndex: selectedRecipeIndex,
+      secondaryActionId: secondaryActionId,
     );
   }
 
@@ -124,6 +153,7 @@ class SkillActivity extends ActiveActivity {
       progressTicks: 0,
       totalTicks: newTotalTicks,
       selectedRecipeIndex: selectedRecipeIndex,
+      secondaryActionId: secondaryActionId,
     );
   }
 
@@ -137,6 +167,8 @@ class SkillActivity extends ActiveActivity {
       'totalTicks': totalTicks,
       if (selectedRecipeIndex != null)
         'selectedRecipeIndex': selectedRecipeIndex,
+      if (secondaryActionId != null)
+        'secondaryActionId': secondaryActionId!.toJson(),
     };
   }
 }

--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -969,7 +969,115 @@ ForegroundResult _completeGenericSkillAction(
   Random random,
 ) {
   final canRepeat = completeAction(builder, action, random: random);
+
+  // Multi-tree woodcutting: also complete the secondary tree
+  final activity = builder.state.activeActivity;
+  if (canRepeat &&
+      activity is SkillActivity &&
+      activity.secondaryActionId != null &&
+      action.skill == Skill.woodcutting) {
+    _completeSecondaryWoodcutting(builder, activity, action, random);
+  }
+
   return _restartOrStop(builder, action, canRepeat, random);
+}
+
+/// Completes the secondary tree in multi-tree woodcutting.
+///
+/// The secondary (faster) tree's output is scaled by M_Action, computed as
+/// floor(primaryMeanTicks / secondaryMeanTicks). XP and mastery are also
+/// scaled by this multiplier.
+void _completeSecondaryWoodcutting(
+  StateUpdateBuilder builder,
+  SkillActivity activity,
+  SkillAction primaryAction,
+  Random random,
+) {
+  final secondaryActionId = ActionId(
+    activity.skill.id,
+    activity.secondaryActionId!,
+  );
+  final secondaryAction = builder.registries.actionById(secondaryActionId);
+  if (secondaryAction is! SkillAction) return;
+
+  // Compute M_Action = floor(primaryMeanTicks / secondaryMeanTicks)
+  final primaryMeanTicks = builder.state.meanDurationWithModifiers(
+    primaryAction,
+  );
+  final secondaryMeanTicks = builder.state.meanDurationWithModifiers(
+    secondaryAction,
+  );
+  final mAction = primaryMeanTicks ~/ secondaryMeanTicks;
+  if (mAction <= 0) return;
+
+  // Roll drops for the secondary tree, applying M_Action to log count.
+  // Handles all drop types (Drop, RareDrop, etc.) correctly.
+  final modifiers = builder.state.createActionModifierProvider(
+    secondaryAction,
+    conditionContext: ConditionContext.empty,
+    consumesOnType: null,
+  );
+  final actionState = builder.state.actionState(secondaryAction.id);
+  final selection = actionState.recipeSelection(secondaryAction);
+  final doublingChance = secondaryAction.doublingChance(modifiers);
+
+  for (final drop in builder.registries.drops.allDropsForAction(
+    secondaryAction,
+    selection,
+  )) {
+    ItemStack? itemStack;
+    if (drop is Drop) {
+      final modifierBonus = modifiers.randomProductChance(
+        itemId: drop.itemId,
+        skillId: secondaryAction.skill.id,
+      );
+      final effectiveRate = (drop.rate + modifierBonus / 100.0).clamp(0.0, 1.0);
+      if (effectiveRate >= 1.0 || random.nextDouble() < effectiveRate) {
+        itemStack = drop.toItemStack(builder.registries.items);
+      }
+    } else if (drop is RareDrop) {
+      final skillLevel = builder.state
+          .skillState(secondaryAction.skill)
+          .skillLevel;
+      final totalMastery = playerTotalMasteryLevelForSkill(
+        builder.state,
+        secondaryAction.skill,
+      );
+      final hasRequiredItem =
+          drop.requiredItemId == null ||
+          builder.state.inventory.hasEverAcquired(drop.requiredItemId!);
+      itemStack = drop.rollWithContext(
+        builder.registries.items,
+        random,
+        skillLevel: skillLevel,
+        totalMastery: totalMastery,
+        hasRequiredItem: hasRequiredItem,
+      );
+    } else {
+      itemStack = drop.roll(builder.registries.items, random);
+    }
+    if (itemStack != null) {
+      // Scale output count by M_Action
+      var count = itemStack.count * mAction;
+      if (doublingChance > 0 && random.nextDouble() < doublingChance) {
+        count *= 2;
+      }
+      builder.addInventory(ItemStack(itemStack.item, count: count));
+    }
+  }
+
+  // Grant scaled XP and mastery
+  final perAction = xpPerAction(builder.state, secondaryAction, modifiers);
+  builder
+    ..addSkillXp(secondaryAction.skill, perAction.xp * mAction)
+    ..addActionMasteryXp(secondaryAction.id, perAction.masteryXp * mAction)
+    ..addSkillMasteryXp(
+      secondaryAction.skill,
+      perAction.masteryPoolXp * mAction,
+    );
+
+  // Roll for summoning mark discovery on secondary tree
+  _rollMarkDiscovery(builder, secondaryAction, random);
 }
 
 /// Restarts the action if it can repeat, otherwise stops with the

--- a/logic/lib/src/state.dart
+++ b/logic/lib/src/state.dart
@@ -731,8 +731,26 @@ class GlobalState {
     };
   }
 
-  /// Returns true if the given action is currently active.
-  bool isActionActive(Action action) => currentActionId == action.id;
+  /// Returns true if the given action is currently active (primary or
+  /// secondary in multi-tree woodcutting).
+  bool isActionActive(Action action) {
+    if (currentActionId == action.id) return true;
+    final activity = activeActivity;
+    if (activity is SkillActivity && activity.secondaryActionId != null) {
+      return ActionId(activity.skill.id, activity.secondaryActionId!) ==
+          action.id;
+    }
+    return false;
+  }
+
+  /// Returns the secondary woodcutting action ID, if multi-tree is active.
+  ActionId? get secondaryWoodcuttingActionId {
+    final activity = activeActivity;
+    if (activity is SkillActivity && activity.secondaryActionId != null) {
+      return ActionId(activity.skill.id, activity.secondaryActionId!);
+    }
+    return null;
+  }
 
   /// The accumulated skill states.
   final Map<Skill, SkillState> skillStates;
@@ -1389,12 +1407,63 @@ class GlobalState {
     );
   }
 
+  /// Starts multi-tree woodcutting, cutting two trees simultaneously.
+  ///
+  /// The slower tree becomes the primary (sets the timer), the faster tree
+  /// becomes the secondary (its output is scaled by M_Action multiplier).
+  GlobalState startMultiTreeWoodcutting(
+    WoodcuttingTree tree1,
+    WoodcuttingTree tree2, {
+    required Random random,
+  }) {
+    if (isStunned) {
+      throw const StunnedException('Cannot start action while stunned');
+    }
+
+    final prepared = _prepareForActivitySwitch(stayingInCooking: false);
+
+    final ticks1 = prepared.rollDurationWithModifiers(
+      tree1,
+      random,
+      registries.shop,
+    );
+    final ticks2 = prepared.rollDurationWithModifiers(
+      tree2,
+      random,
+      registries.shop,
+    );
+
+    // Primary tree is the slower one (sets the timer)
+    final WoodcuttingTree primary;
+    final WoodcuttingTree secondary;
+    final int totalTicks;
+    if (ticks1 >= ticks2) {
+      primary = tree1;
+      secondary = tree2;
+      totalTicks = ticks1;
+    } else {
+      primary = tree2;
+      secondary = tree1;
+      totalTicks = ticks2;
+    }
+
+    return prepared.copyWith(
+      activeActivity: SkillActivity(
+        skill: Skill.woodcutting,
+        actionId: primary.id.localId,
+        progressTicks: 0,
+        totalTicks: totalTicks,
+        secondaryActionId: secondary.id.localId,
+      ),
+    );
+  }
+
   /// Starts an action using deterministic mean duration (no randomness).
   ///
   /// Used during planning/solver to get consistent state projections.
   /// For actual gameplay execution, use [startAction] instead.
   GlobalState startActionDeterministic(Action action) {
-    return _startActionImpl(action, skillDuration: _meanDurationWithModifiers);
+    return _startActionImpl(action, skillDuration: meanDurationWithModifiers);
   }
 
   GlobalState _startActionImpl(
@@ -1830,7 +1899,7 @@ class GlobalState {
   }
 
   /// Calculates mean duration with modifiers applied (deterministic).
-  int _meanDurationWithModifiers(SkillAction action) {
+  int meanDurationWithModifiers(SkillAction action) {
     final ticks = ticksFromDuration(action.meanDuration);
     final modifiers = createActionModifierProvider(
       action,
@@ -1938,10 +2007,14 @@ class GlobalState {
 
   int activeProgress(Action action) {
     final activity = activeActivity;
-    if (activity == null || currentActionId != action.id) {
-      return 0;
+    if (activity == null) return 0;
+    // Primary action match
+    if (currentActionId == action.id) return activity.progressTicks;
+    // Secondary action in multi-tree shares the same progress bar
+    if (secondaryWoodcuttingActionId == action.id) {
+      return activity.progressTicks;
     }
-    return activity.progressTicks;
+    return 0;
   }
 
   GlobalState updateActiveActivity(

--- a/logic/lib/src/state_update_builder.dart
+++ b/logic/lib/src/state_update_builder.dart
@@ -87,6 +87,32 @@ class StateUpdateBuilder {
   void restartCurrentAction(Action action, {required Random random}) {
     final activity = _state.activeActivity;
     if (activity != null && action is SkillAction) {
+      // For multi-tree woodcutting, roll both durations and use max
+      if (activity is SkillActivity && activity.secondaryActionId != null) {
+        final secondaryActionId = ActionId(
+          activity.skill.id,
+          activity.secondaryActionId!,
+        );
+        final secondaryAction = registries.actionById(secondaryActionId);
+        if (secondaryAction is SkillAction) {
+          final primaryTicks = _state.rollDurationWithModifiers(
+            action,
+            random,
+            registries.shop,
+          );
+          final secondaryTicks = _state.rollDurationWithModifiers(
+            secondaryAction,
+            random,
+            registries.shop,
+          );
+          final newTotalTicks = max(primaryTicks, secondaryTicks);
+          _state = _state.copyWith(
+            activeActivity: activity.restarted(newTotalTicks: newTotalTicks),
+          );
+          return;
+        }
+      }
+
       // Use the activity's restarted method to preserve internal state
       // (e.g., CookingActivity preserves passive area progress)
       final newTotalTicks = _state.rollDurationWithModifiers(

--- a/logic/test/multi_tree_woodcutting_test.dart
+++ b/logic/test/multi_tree_woodcutting_test.dart
@@ -1,0 +1,291 @@
+import 'dart:math';
+
+import 'package:logic/logic.dart';
+import 'package:test/test.dart';
+
+import 'test_helper.dart';
+
+void main() {
+  late WoodcuttingTree normalTree;
+  late WoodcuttingTree oakTree;
+  late Item normalLogs;
+  late Item oakLogs;
+
+  setUpAll(() async {
+    await loadTestRegistries();
+
+    normalTree =
+        testRegistries.woodcuttingAction('Normal Tree') as WoodcuttingTree;
+    oakTree = testRegistries.woodcuttingAction('Oak Tree') as WoodcuttingTree;
+
+    normalLogs = testItems.byName('Normal Logs');
+    oakLogs = testItems.byName('Oak Logs');
+  });
+
+  /// Creates a state with the Multi_Tree shop purchase.
+  GlobalState stateWithMultiTree() {
+    return GlobalState.test(
+      testRegistries,
+      shop: const ShopState.empty().withPurchase(
+        MelvorId.fromJson('melvorD:Multi_Tree'),
+      ),
+    );
+  }
+
+  group('multi-tree woodcutting', () {
+    test('startMultiTreeWoodcutting sets secondaryActionId', () {
+      final random = Random(0);
+      var state = stateWithMultiTree();
+      state = state.startMultiTreeWoodcutting(
+        normalTree,
+        oakTree,
+        random: random,
+      );
+
+      final activity = state.activeActivity! as SkillActivity;
+      expect(activity.secondaryActionId, isNotNull);
+      expect(activity.skill, Skill.woodcutting);
+    });
+
+    test('slower tree becomes primary, faster tree becomes secondary', () {
+      final random = Random(0);
+      var state = stateWithMultiTree();
+      state = state.startMultiTreeWoodcutting(
+        normalTree,
+        oakTree,
+        random: random,
+      );
+
+      final activity = state.activeActivity! as SkillActivity;
+      // Oak (4s) is slower -> primary, Normal (3s) is faster -> secondary
+      expect(activity.actionId, oakTree.id.localId);
+      expect(activity.secondaryActionId, normalTree.id.localId);
+    });
+
+    test('totalTicks equals the slower tree duration', () {
+      final random = Random(0);
+      var state = stateWithMultiTree();
+      state = state.startMultiTreeWoodcutting(
+        normalTree,
+        oakTree,
+        random: random,
+      );
+
+      final activity = state.activeActivity! as SkillActivity;
+      // Oak Tree has fixed duration, totalTicks should be Oak's duration
+      // (40 ticks = 4 seconds)
+      expect(activity.totalTicks, 40);
+    });
+
+    test('isActionActive returns true for both trees', () {
+      final random = Random(0);
+      var state = stateWithMultiTree();
+      state = state.startMultiTreeWoodcutting(
+        normalTree,
+        oakTree,
+        random: random,
+      );
+
+      expect(state.isActionActive(oakTree), isTrue);
+      expect(state.isActionActive(normalTree), isTrue);
+    });
+
+    test('activeProgress returns progress for both trees', () {
+      final random = Random(0);
+      var state = stateWithMultiTree();
+      state = state.startMultiTreeWoodcutting(
+        normalTree,
+        oakTree,
+        random: random,
+      );
+
+      // Both trees should share the same progress (starts at 0)
+      expect(state.activeProgress(oakTree), 0);
+      expect(state.activeProgress(normalTree), 0);
+    });
+
+    test('completing one cycle produces logs from both trees', () {
+      final random = Random(0);
+      var state = stateWithMultiTree();
+      state = state.startMultiTreeWoodcutting(
+        normalTree,
+        oakTree,
+        random: random,
+      );
+
+      // Complete one full cycle (40 ticks for Oak Tree)
+      final builder = StateUpdateBuilder(state);
+      consumeTicks(builder, 40, random: random);
+      state = builder.build();
+
+      // Both logs should be in inventory
+      final normalLogsCount = state.inventory.countOfItem(normalLogs);
+      final oakLogsCount = state.inventory.countOfItem(oakLogs);
+
+      // Oak logs: 1 (primary, completes once)
+      expect(oakLogsCount, 1);
+      // Normal logs: M_Action = floor(40/30) = 1 (both fixed duration)
+      // (M_Action multiplier scales the secondary tree's output)
+      expect(normalLogsCount, greaterThanOrEqualTo(1));
+    });
+
+    test('XP is awarded for both trees', () {
+      final random = Random(0);
+      var state = stateWithMultiTree();
+      state = state.startMultiTreeWoodcutting(
+        normalTree,
+        oakTree,
+        random: random,
+      );
+
+      final builder = StateUpdateBuilder(state);
+      consumeTicks(builder, 40, random: random);
+      state = builder.build();
+
+      // Woodcutting XP should include both trees' contributions
+      final wcXp = state.skillState(Skill.woodcutting).xp;
+      // Primary (oak) XP + secondary (normal) XP * M_Action
+      expect(wcXp, greaterThan(oakTree.xp));
+    });
+
+    test('mastery is awarded for both trees', () {
+      final random = Random(0);
+      var state = stateWithMultiTree();
+      state = state.startMultiTreeWoodcutting(
+        normalTree,
+        oakTree,
+        random: random,
+      );
+
+      final builder = StateUpdateBuilder(state);
+      consumeTicks(builder, 40, random: random);
+      state = builder.build();
+
+      // Both trees should gain mastery XP
+      final oakMastery = state.actionState(oakTree.id).masteryXp;
+      final normalMastery = state.actionState(normalTree.id).masteryXp;
+      expect(oakMastery, greaterThan(0));
+      expect(normalMastery, greaterThan(0));
+    });
+
+    test('without Multi_Tree purchase, second tree starts alone', () {
+      final random = Random(0);
+      var state = GlobalState.empty(testRegistries);
+
+      // Start normal tree first
+      state = state.startAction(normalTree, random: random);
+      expect(state.isActionActive(normalTree), isTrue);
+
+      // Start oak tree - should replace normal tree (no multi-tree)
+      state = state.startAction(oakTree, random: random);
+      expect(state.isActionActive(oakTree), isTrue);
+      expect(state.isActionActive(normalTree), isFalse);
+
+      final activity = state.activeActivity! as SkillActivity;
+      expect(activity.secondaryActionId, isNull);
+    });
+
+    test('clicking active primary tree stops both', () {
+      final random = Random(0);
+      var state = stateWithMultiTree();
+      state = state.startMultiTreeWoodcutting(
+        normalTree,
+        oakTree,
+        random: random,
+      );
+
+      // isActionActive returns true for both
+      expect(state.isActionActive(oakTree), isTrue);
+      expect(state.isActionActive(normalTree), isTrue);
+
+      // Clear action (simulates clicking active tree)
+      state = state.clearAction();
+      expect(state.activeActivity, isNull);
+      expect(state.isActionActive(oakTree), isFalse);
+      expect(state.isActionActive(normalTree), isFalse);
+    });
+
+    test('JSON round-trip preserves secondaryActionId', () {
+      final random = Random(0);
+      var state = stateWithMultiTree();
+      state = state.startMultiTreeWoodcutting(
+        normalTree,
+        oakTree,
+        random: random,
+      );
+
+      // Serialize and deserialize
+      final json = state.toJson();
+      final restored = GlobalState.fromJson(testRegistries, json);
+
+      final activity = restored.activeActivity! as SkillActivity;
+      expect(activity.secondaryActionId, isNotNull);
+      expect(activity.actionId, oakTree.id.localId);
+      expect(activity.secondaryActionId, normalTree.id.localId);
+    });
+
+    test('restart uses max duration of both trees', () {
+      final random = Random(0);
+      var state = stateWithMultiTree();
+      state = state.startMultiTreeWoodcutting(
+        normalTree,
+        oakTree,
+        random: random,
+      );
+
+      // Complete one cycle and let it restart
+      final builder = StateUpdateBuilder(state);
+      consumeTicks(builder, 40, random: random);
+      state = builder.build();
+
+      // After restart, should still have multi-tree active
+      final activity = state.activeActivity! as SkillActivity;
+      expect(activity.secondaryActionId, normalTree.id.localId);
+      // totalTicks should be max of both trees' durations (40 for Oak)
+      expect(activity.totalTicks, 40);
+    });
+
+    test('multiple completions accumulate correctly', () {
+      final random = Random(0);
+      var state = stateWithMultiTree();
+      state = state.startMultiTreeWoodcutting(
+        normalTree,
+        oakTree,
+        random: random,
+      );
+
+      // Complete 3 cycles (3 * 40 = 120 ticks)
+      final builder = StateUpdateBuilder(state);
+      consumeTicks(builder, 120, random: random);
+      state = builder.build();
+
+      // Oak logs should be at least 3
+      final oakLogsCount = state.inventory.countOfItem(oakLogs);
+      expect(oakLogsCount, greaterThanOrEqualTo(3));
+
+      // Normal logs should be at least 3 (M_Action=1 * 3 cycles)
+      final normalLogsCount = state.inventory.countOfItem(normalLogs);
+      expect(normalLogsCount, greaterThanOrEqualTo(3));
+    });
+
+    test('secondaryWoodcuttingActionId returns correct ID', () {
+      final random = Random(0);
+      var state = stateWithMultiTree();
+      state = state.startMultiTreeWoodcutting(
+        normalTree,
+        oakTree,
+        random: random,
+      );
+
+      expect(state.secondaryWoodcuttingActionId, normalTree.id);
+    });
+
+    test('secondaryWoodcuttingActionId returns null for single tree', () {
+      final random = Random(0);
+      var state = GlobalState.empty(testRegistries);
+      state = state.startAction(normalTree, random: random);
+
+      expect(state.secondaryWoodcuttingActionId, isNull);
+    });
+  });
+}

--- a/ui/lib/src/logic/redux_actions.dart
+++ b/ui/lib/src/logic/redux_actions.dart
@@ -76,9 +76,34 @@ class ToggleActionAction extends ReduxAction<GlobalState> {
     if (state.isStunned) {
       return null;
     }
-    // If the action is already running, stop it
+    // If the action is already running (primary or secondary), stop it
     if (state.isActionActive(action)) {
       return state.clearAction();
+    }
+    // Multi-tree woodcutting: if already cutting one tree and clicking a
+    // different tree, check if the player has the Multi-Tree upgrade.
+    if (action is WoodcuttingTree) {
+      final activity = state.activeActivity;
+      if (activity is SkillActivity &&
+          activity.skill == Skill.woodcutting &&
+          activity.secondaryActionId == null) {
+        final modifiers = state.createGlobalModifierProvider(
+          conditionContext: ConditionContext.empty,
+        );
+        if (modifiers.treeCutLimit >= 1) {
+          final currentTree = state.registries.woodcutting.byId(
+            activity.actionId,
+          );
+          if (currentTree != null) {
+            final random = Random();
+            return state.startMultiTreeWoodcutting(
+              currentTree,
+              action as WoodcuttingTree,
+              random: random,
+            );
+          }
+        }
+      }
     }
     // Otherwise, start this action (stops any other active action).
     final random = Random();


### PR DESCRIPTION
## Summary
- Implements the Multi-Tree shop purchase mechanic (`melvorD:Multi_Tree`) allowing two trees to be cut simultaneously
- Slower tree becomes primary (sets the timer), faster tree becomes secondary with output scaled by `M_Action = floor(slowDuration / fastDuration)`
- Both trees produce logs, XP, and mastery each cycle; secondary tree's rewards are multiplied by M_Action
- UI automatically activates multi-tree when clicking a second tree while one is already being cut (if shop purchase owned)

## Changes
- **SkillActivity**: added `secondaryActionId` field with full serialization support
- **GlobalState**: `isActionActive`/`activeProgress` check both trees; added `startMultiTreeWoodcutting` and `secondaryWoodcuttingActionId`
- **consume_ticks**: `_completeSecondaryWoodcutting` handles secondary tree drops/XP/mastery with M_Action scaling
- **StateUpdateBuilder**: `restartCurrentAction` rolls both durations and uses max
- **ToggleActionAction** (UI): detects multi-tree eligibility and routes to `startMultiTreeWoodcutting`

## Test plan
- [x] 15 new tests in `logic/test/multi_tree_woodcutting_test.dart`
- [x] All 2244 existing logic tests pass
- [x] `dart analyze --fatal-infos` clean (logic + ui)
- [x] `dart format` applied
- [x] `npx cspell` clean