### PR TITLE
feat: add View Contents dialog for openable items

### DIFF
--- a/ui/lib/src/screens/bank.dart
+++ b/ui/lib/src/screens/bank.dart
@@ -13,6 +13,7 @@ import 'package:ui/src/widgets/game_scaffold.dart';
 import 'package:ui/src/widgets/item_image.dart';
 import 'package:ui/src/widgets/navigation_drawer.dart';
 import 'package:ui/src/widgets/open_result_dialog.dart';
+import 'package:ui/src/widgets/openable_contents_dialog.dart';
 import 'package:ui/src/widgets/style.dart';
 
 class BankPage extends StatefulWidget {
@@ -787,42 +788,6 @@ class _OpenItemSectionState extends State<_OpenItemSection> {
     }
   }
 
-  void _showContentsDialog(BuildContext context) {
-    final dropTable = widget.item.dropTable!;
-    final items = context.state.registries.items;
-    showDialog<void>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text('${widget.item.name} Contents'),
-        content: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              for (final entry in dropTable.entries)
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 4),
-                  child: Text(
-                    entry.minQuantity == entry.maxQuantity
-                        ? '${entry.maxQuantity}x '
-                              '${items.byId(entry.itemID).name}'
-                        : 'Up to ${entry.maxQuantity}x '
-                              '${items.byId(entry.itemID).name}',
-                  ),
-                ),
-            ],
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(),
-            child: const Text('OK'),
-          ),
-        ],
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final openCountInt = _openCount.round().clamp(1, widget.maxCount);
@@ -833,8 +798,8 @@ class _OpenItemSectionState extends State<_OpenItemSection> {
         Text('Open Item', style: Theme.of(context).textTheme.titleMedium),
         const SizedBox(height: 8),
         TextButton(
-          onPressed: () => _showContentsDialog(context),
-          child: const Text('View Possible Contents'),
+          onPressed: () => showOpenableContentsDialog(context, widget.item),
+          child: const Text('View Contents'),
         ),
         const SizedBox(height: 8),
         Text(

--- a/ui/lib/src/widgets/openable_contents_dialog.dart
+++ b/ui/lib/src/widgets/openable_contents_dialog.dart
@@ -1,0 +1,105 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
+import 'package:logic/logic.dart';
+import 'package:ui/src/widgets/context_extensions.dart';
+import 'package:ui/src/widgets/item_image.dart';
+
+/// Shows a dialog displaying the possible contents of an openable item.
+void showOpenableContentsDialog(BuildContext context, Item item) {
+  showDialog<void>(
+    context: context,
+    builder: (context) => OpenableContentsDialog(item: item),
+  );
+}
+
+/// A dialog that displays the possible contents of an openable item.
+class OpenableContentsDialog extends StatelessWidget {
+  const OpenableContentsDialog({required this.item, super.key});
+
+  final Item item;
+
+  @override
+  Widget build(BuildContext context) {
+    final items = context.state.registries.items;
+    final dropTable = item.dropTable;
+
+    return AlertDialog(
+      title: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ItemImage(item: item, size: 48),
+          const SizedBox(height: 8),
+          Text(item.name),
+        ],
+      ),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Possible contents:',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            if (dropTable != null)
+              ...dropTable.entries
+                  .sorted((a, b) => b.weight.compareTo(a.weight))
+                  .map((entry) {
+                    final entryItem = items.byId(entry.itemID);
+                    return _DropRow(
+                      prefix: _formatQuantity(
+                        entry.minQuantity,
+                        entry.maxQuantity,
+                      ),
+                      icon: ItemImage(item: entryItem, size: 20),
+                      name: entryItem.name,
+                    );
+                  }),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+
+  String _formatQuantity(int min, int max) {
+    if (min == max) {
+      return '$min x';
+    }
+    return 'Up to $max x';
+  }
+}
+
+class _DropRow extends StatelessWidget {
+  const _DropRow({
+    required this.prefix,
+    required this.icon,
+    required this.name,
+  });
+
+  final String prefix;
+  final Widget icon;
+  final String name;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 8, bottom: 4),
+      child: Row(
+        children: [
+          Text(prefix),
+          const SizedBox(width: 4),
+          icon,
+          const SizedBox(width: 4),
+          Expanded(child: Text(name)),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a "View Contents" button in the bank item drawer for openable items
- Opens a dialog showing the item image, item name, "Possible contents:" label, and each drop with quantity, item icon, and name
- Drops sorted by weight (most common first)

## Test plan
- [ ] Open bank, select an openable item (e.g., Egg Chest)
- [ ] Verify "View Contents" button appears below item name
- [ ] Tap button and verify dialog shows item image, name, "Possible contents:" header, and drop entries with icons