### PR TITLE
fix: hide equip buttons for locked equipment slots

### DIFF
--- a/ui/lib/src/screens/bank.dart
+++ b/ui/lib/src/screens/bank.dart
@@ -917,8 +917,8 @@ class _EquipGearSection extends StatelessWidget {
     final state = context.state;
     final equipment = state.equipment;
 
-    // Get valid slots from the item
-    final validSlots = item.validSlots;
+    // Get valid slots from the item, excluding locked slots.
+    final validSlots = item.validSlots.where(state.isSlotUnlocked).toList();
 
     // Find which slot this item is currently equipped in (if any)
     EquipmentSlot? currentlyEquippedSlot;


### PR DESCRIPTION
## Summary
- Filters locked equipment slots (like Passive) out of the item drawer's equip buttons, so players only see slots they've actually unlocked
- Also includes prior commits: improved item detail drawer for openable items (view contents, reordered sections, sell slider improvements)

## Test plan
- [ ] Open item drawer for an equippable item before unlocking the Passive slot — verify no "Equip in Passive" button appears
- [ ] After unlocking the Passive slot (completing "Into the Mist"), verify the button reappears