### PR TITLE
feat: add confirmation dialog for single-item sell

### DIFF
--- a/ui/lib/src/screens/bank.dart
+++ b/ui/lib/src/screens/bank.dart
@@ -608,14 +608,26 @@ class _ItemDetailsContentState extends State<_ItemDetailsContent> {
               width: double.infinity,
               child: ElevatedButton(
                 onPressed: sellCountInt > 0
-                    ? () {
-                        context.dispatch(
-                          SellItemAction(
-                            item: widget.stack.item,
-                            count: sellCountInt,
-                          ),
+                    ? () async {
+                        final stack = ItemStack(
+                          widget.stack.item,
+                          count: sellCountInt,
                         );
-                        widget.onClose();
+                        final confirmed = await showDialog<bool>(
+                          context: context,
+                          builder: (dialogContext) =>
+                              _SellConfirmationDialog(stacks: [stack]),
+                        );
+                        if (!context.mounted) return;
+                        if (confirmed ?? false) {
+                          context.dispatch(
+                            SellItemAction(
+                              item: widget.stack.item,
+                              count: sellCountInt,
+                            ),
+                          );
+                          widget.onClose();
+                        }
                       }
                     : null,
                 child: const Text('Sell'),


### PR DESCRIPTION
## Summary
- Show a confirmation dialog when selling items from the bank item drawer
- Reuses the existing `_SellConfirmationDialog` already used for multi-select sells

## Test plan
- [ ] Open bank, select an item, adjust sell count, click Sell
- [ ] Verify confirmation dialog appears showing item, count, and total value
- [ ] Cancel dismisses dialog without selling
- [ ] Confirm sells the items and closes the drawer