### PR TITLE
fix: use correct icon for currency toasts

### DIFF
--- a/ui/lib/src/widgets/toast_overlay.dart
+++ b/ui/lib/src/widgets/toast_overlay.dart
@@ -324,7 +324,7 @@ class _ToastOverlayState extends State<ToastOverlay>
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            CachedImage(assetPath: Currency.gp.assetPath, size: 20),
+            CachedImage(assetPath: currency.assetPath, size: 20),
             const SizedBox(width: 8),
             Text(
               signedCountString(amount),


### PR DESCRIPTION
## Summary
- Fixed toast overlay hardcoding the GP icon for all currency types
- Slayer coins and raid coins now display their correct icons in toast notifications

## Test plan
- [ ] Earn slayer coins (e.g. complete a quest) and verify the toast shows the slayer coin icon, not the GP icon