### PR TITLE
fix: show toast when harvesting crops

### DIFF
--- a/logic/lib/src/state.dart
+++ b/logic/lib/src/state.dart
@@ -3094,8 +3094,8 @@ class GlobalState {
     return copyWith(inventory: newInventory, plotStates: newPlotStates);
   }
 
-  /// Harvests a ready crop from a plot.
-  GlobalState harvestCrop(MelvorId plotId, Random random) {
+  /// Harvests a ready crop from a plot, returning both new state and changes.
+  (GlobalState, Changes) harvestCrop(MelvorId plotId, Random random) {
     // Validate plot has a ready crop
     final plotState = plotStates[plotId];
     if (plotState == null || !plotState.isReadyToHarvest) {
@@ -3129,7 +3129,7 @@ class GlobalState {
     if (!succeeded) {
       final newPlotStates = Map<MelvorId, PlotState>.from(plotStates)
         ..remove(plotId);
-      return copyWith(plotStates: newPlotStates);
+      return (copyWith(plotStates: newPlotStates), const Changes.empty());
     }
 
     // Calculate harvest quantity
@@ -3145,6 +3145,11 @@ class GlobalState {
 
     // Add harvested items to inventory
     var newInventory = inventory.adding(ItemStack(product, count: quantity));
+
+    // Track changes for toast
+    var changes = const Changes.empty().adding(
+      ItemStack(product, count: quantity),
+    );
 
     // Roll for seed return if category allows
     if (category.returnSeeds) {
@@ -3163,6 +3168,7 @@ class GlobalState {
         newInventory = newInventory.adding(
           ItemStack(seed, count: seedsReturned),
         );
+        changes = changes.adding(ItemStack(seed, count: seedsReturned));
       }
     }
 
@@ -3175,13 +3181,20 @@ class GlobalState {
     final xpAmount = category.scaleXPWithQuantity
         ? crop.baseXP * quantity
         : crop.baseXP;
+    final oldLevel = skillState(Skill.farming).skillLevel;
     newState = newState.addSkillXp(Skill.farming, xpAmount);
+    final newLevel = newState.skillState(Skill.farming).skillLevel;
+
+    changes = changes.addingSkillXp(Skill.farming, xpAmount);
+    if (newLevel > oldLevel) {
+      changes = changes.addingSkillLevel(Skill.farming, oldLevel, newLevel);
+    }
 
     // Award mastery XP
     final masteryXpAmount = crop.baseXP ~/ category.masteryXPDivider;
     newState = newState.addActionMasteryXp(cropId, masteryXpAmount);
 
-    return newState.clearPlot(plotId);
+    return (newState.clearPlot(plotId), changes);
   }
 
   /// Clears a farming plot, destroying any growing crop and compost.

--- a/logic/test/consume_ticks_test.dart
+++ b/logic/test/consume_ticks_test.dart
@@ -1418,7 +1418,7 @@ void main() {
       expect(state.plotStates[plotId]!.isReadyToHarvest, true);
 
       // Harvest the crop
-      state = state.harvestCrop(plotId, random);
+      (state, _) = state.harvestCrop(plotId, random);
 
       // Verify product was added to inventory
       expect(state.inventory.countOfItem(product), greaterThan(0));

--- a/logic/test/data/farming_test.dart
+++ b/logic/test/data/farming_test.dart
@@ -181,7 +181,7 @@ void main() {
       state = state.copyWith(plotStates: {plotId: readyPlotState});
 
       final xpBefore = state.skillState(Skill.farming).xp;
-      state = state.harvestCrop(plotId, random);
+      (state, _) = state.harvestCrop(plotId, random);
       final xpAfter = state.skillState(Skill.farming).xp;
 
       // Tree harvest should give exactly baseXP (not scaled)
@@ -210,7 +210,7 @@ void main() {
       state = state.copyWith(plotStates: {plotId: readyPlotState});
 
       final xpBeforeHarvest = state.skillState(Skill.farming).xp;
-      state = state.harvestCrop(plotId, random);
+      (state, _) = state.harvestCrop(plotId, random);
       final xpAfterHarvest = state.skillState(Skill.farming).xp;
 
       // Determine how many items were harvested
@@ -263,7 +263,7 @@ void main() {
         state = state.copyWith(plotStates: {plotId: readyPlotState});
 
         final product = testRegistries.items.byId(allotmentCrop.productId);
-        state = state.harvestCrop(plotId, random);
+        (state, _) = state.harvestCrop(plotId, random);
 
         if (state.inventory.countOfItem(product) > 0) {
           successCount++;
@@ -300,7 +300,7 @@ void main() {
       state = state.copyWith(plotStates: {plotId: readyPlotState});
 
       final product = testRegistries.items.byId(allotmentCrop.productId);
-      state = state.harvestCrop(plotId, random);
+      (state, _) = state.harvestCrop(plotId, random);
 
       // With 100% success, we should always get the product
       expect(state.inventory.countOfItem(product), greaterThan(0));
@@ -339,7 +339,7 @@ void main() {
       state = state.copyWith(plotStates: {plotId: readyPlotState});
 
       final product = testRegistries.items.byId(allotmentCrop.productId);
-      state = state.harvestCrop(plotId, random);
+      (state, _) = state.harvestCrop(plotId, random);
 
       // With a failing seed at 50% chance, we should get no product
       expect(state.inventory.countOfItem(product), 0);
@@ -386,7 +386,7 @@ void main() {
       );
 
       final product = testRegistries.items.byId(allotmentCrop.productId);
-      stateWithout = stateWithout.harvestCrop(plotId, Random(42));
+      (stateWithout, _) = stateWithout.harvestCrop(plotId, Random(42));
       final quantityWithout = stateWithout.inventory.countOfItem(product);
 
       // Now harvest with 50% harvest bonus (large enough to see the difference)
@@ -406,7 +406,7 @@ void main() {
       );
       stateWith = stateWith.copyWith(plotStates: {plotId: plotStateWith});
 
-      stateWith = stateWith.harvestCrop(plotId, Random(42));
+      (stateWith, _) = stateWith.harvestCrop(plotId, Random(42));
       final quantityWith = stateWith.inventory.countOfItem(product);
 
       // Calculate expected values

--- a/logic/test/state_test.dart
+++ b/logic/test/state_test.dart
@@ -1618,7 +1618,7 @@ void main() {
       expect(state.plotStates[plotId]!.isReadyToHarvest, true);
 
       // Harvest (note: 50% success rate with no compost, may fail)
-      state = state.harvestCrop(plotId, random);
+      (state, _) = state.harvestCrop(plotId, random);
 
       // Plot should be cleared regardless of success/failure
       final plotStateAfterFirstHarvest = state.plotStates[plotId];
@@ -1664,7 +1664,7 @@ void main() {
       state = state.copyWith(plotStates: {plotId: readyPlotState});
 
       // Harvest (note: 50% success rate, but we check XP regardless)
-      state = state.harvestCrop(plotId, random);
+      (state, _) = state.harvestCrop(plotId, random);
 
       // Verify XP was awarded (either on plant or harvest, depending)
       final xpAfterHarvest = state.skillState(Skill.farming).xp;
@@ -1727,7 +1727,7 @@ void main() {
       state = state.copyWith(plotStates: {plotId: readyPlotState});
 
       // Harvest without harvest bonus
-      state = state.harvestCrop(plotId, Random(42));
+      (state, _) = state.harvestCrop(plotId, Random(42));
       final harvestWithoutBonus = state.inventory.countOfItem(product);
 
       // Reset inventory for second harvest
@@ -1748,7 +1748,7 @@ void main() {
       state = state.copyWith(plotStates: {plotId: readyPlotState});
 
       // Harvest with harvest bonus
-      state = state.harvestCrop(plotId, Random(42));
+      (state, _) = state.harvestCrop(plotId, Random(42));
       final harvestWithBonus = state.inventory.countOfItem(product);
 
       // With 50% harvest bonus, should get more product

--- a/ui/lib/src/logic/redux_actions.dart
+++ b/ui/lib/src/logic/redux_actions.dart
@@ -712,7 +712,13 @@ class HarvestCropAction extends ReduxAction<GlobalState> {
   @override
   GlobalState reduce() {
     final random = Random();
-    return state.harvestCrop(plotId, random);
+    final (newState, changes) = state.harvestCrop(plotId, random);
+
+    if (!changes.isEmpty) {
+      toastService.showToast(changes);
+    }
+
+    return newState;
   }
 }
 


### PR DESCRIPTION
## Summary
- `harvestCrop()` now returns `(GlobalState, Changes)` so the UI can display what was harvested
- `HarvestCropAction` shows a toast with harvested items, returned seeds, farming XP, and level-ups
- Previously harvesting gave no visual feedback despite items being added to inventory

## Test plan
- [x] All existing logic tests pass (2244 passing)
- [ ] Harvest a crop and verify toast shows harvested items
- [ ] Harvest a crop from an allotment category and verify returned seeds appear in toast
- [ ] Verify failed harvests (crop dies) show no toast