### PR TITLE
feat: add compost/gloop inventory indicators to farming page

### DIFF
--- a/ui/lib/src/screens/farming.dart
+++ b/ui/lib/src/screens/farming.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart' hide Action;
+import 'package:go_router/go_router.dart';
 import 'package:logic/logic.dart';
 import 'package:ui/src/logic/redux_actions.dart';
 import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/cost_row.dart';
 import 'package:ui/src/widgets/game_scaffold.dart';
+import 'package:ui/src/widgets/item_count_badge_cell.dart';
 import 'package:ui/src/widgets/item_image.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
 import 'package:ui/src/widgets/skill_fab.dart';
@@ -38,6 +40,7 @@ class FarmingPage extends StatelessWidget {
         children: [
           SkillProgress(xp: skillState.xp),
           const MasteryPoolProgress(skill: skill),
+          _CompostIndicators(registries: registries),
           Expanded(
             child: SingleChildScrollView(
               padding: const EdgeInsets.all(16),
@@ -50,6 +53,41 @@ class FarmingPage extends StatelessWidget {
               ),
             ),
           ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CompostIndicators extends StatelessWidget {
+  const _CompostIndicators({required this.registries});
+
+  final Registries registries;
+
+  @override
+  Widget build(BuildContext context) {
+    final state = context.state;
+    final compostItems = registries.items.all
+        .where((item) => item.compostValue != null && item.compostValue != 0)
+        .toList();
+
+    if (compostItems.isEmpty) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        children: [
+          for (final item in compostItems)
+            GestureDetector(
+              onTap: () => context.go('/shop'),
+              child: ItemCountBadgeCell(
+                item: item,
+                count: state.inventory.countOfItem(item),
+                showShopBadge: true,
+              ),
+            ),
         ],
       ),
     );

--- a/ui/lib/src/widgets/item_count_badge_cell.dart
+++ b/ui/lib/src/widgets/item_count_badge_cell.dart
@@ -19,6 +19,7 @@ class ItemCountBadgeCell extends StatelessWidget {
     required this.item,
     required this.count,
     this.hasEnough,
+    this.showShopBadge = false,
     this.inradius = TextBadgeCell.defaultInradius,
     super.key,
   });
@@ -26,6 +27,7 @@ class ItemCountBadgeCell extends StatelessWidget {
   final Item item;
   final int count;
   final bool? hasEnough;
+  final bool showShopBadge;
   final double inradius;
 
   @override
@@ -42,14 +44,28 @@ class ItemCountBadgeCell extends StatelessWidget {
     return Tooltip(
       message: item.name,
       preferBelow: false,
-      child: CountBadgeCell(
-        inradius: inradius,
-        backgroundColor: Style.xpBadgeBackgroundColor,
-        borderColor: borderColor,
-        count: count,
-        child: Center(
-          child: ItemImage(item: item, size: iconSize),
-        ),
+      child: Stack(
+        children: [
+          CountBadgeCell(
+            inradius: inradius,
+            backgroundColor: Style.xpBadgeBackgroundColor,
+            borderColor: borderColor,
+            count: count,
+            child: Center(
+              child: ItemImage(item: item, size: iconSize),
+            ),
+          ),
+          if (showShopBadge)
+            const Positioned(
+              top: 1,
+              left: 1,
+              child: Icon(
+                Icons.shopping_cart,
+                size: 14,
+                color: Style.badgeTextColor,
+              ),
+            ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Adds `showShopBadge` option to `ItemCountBadgeCell` that overlays a small shopping cart icon in the top-left corner
- Shows compost and Weird Gloop item counts at the top of the farming page, between mastery pool progress and the plot list
- Tapping a compost indicator navigates to the shop

## Test plan
- [x] `flutter test` passes (164 tests)
- [x] `dart analyze --fatal-infos` clean on changed files
- [x] `dart format` applied
- [ ] Visual check: farming page shows compost item icons with counts and a small shop badge