### PR TITLE
feat: add Harvest All and Plant All buttons to farming

### DIFF
--- a/logic/lib/src/state.dart
+++ b/logic/lib/src/state.dart
@@ -3205,6 +3205,86 @@ class GlobalState {
     return (newState.clearPlot(plotId), changes);
   }
 
+  /// Harvests all ready crops in a category.
+  /// Returns null if can't afford 2,000 GP or no plots are ready.
+  (GlobalState, Changes)? harvestAllCrops(MelvorId categoryId, Random random) {
+    const gpCost = 2000;
+    if (gp < gpCost) return null;
+
+    final plots = registries.farming.plotsForCategory(categoryId);
+    final readyPlotIds = plots
+        .where(
+          (plot) =>
+              unlockedPlots.contains(plot.id) &&
+              (plotStates[plot.id]?.isReadyToHarvest ?? false),
+        )
+        .map((plot) => plot.id)
+        .toList();
+
+    if (readyPlotIds.isEmpty) return null;
+
+    var state = addCurrency(Currency.gp, -gpCost);
+    var changes = const Changes.empty();
+
+    for (final plotId in readyPlotIds) {
+      final (newState, plotChanges) = state.harvestCrop(plotId, random);
+      state = newState;
+      changes = changes.merge(plotChanges);
+    }
+
+    return (state, changes);
+  }
+
+  /// Plants a crop in all empty plots of a category.
+  /// Returns null if can't afford GP cost or no empty plots exist.
+  /// GP cost is 5,000 base + 2,000 if compost is selected.
+  /// Stops planting if seeds or compost run out.
+  GlobalState? plantAllCrops(
+    MelvorId categoryId,
+    FarmingCrop crop,
+    Item? compost,
+    int compostCount,
+  ) {
+    final gpCost = 5000 + (compost != null ? 2000 : 0);
+    if (gp < gpCost) return null;
+
+    final plots = registries.farming.plotsForCategory(categoryId);
+    final emptyPlotIds = plots
+        .where(
+          (plot) =>
+              unlockedPlots.contains(plot.id) &&
+              (plotStates[plot.id]?.isEmpty ?? true),
+        )
+        .map((plot) => plot.id)
+        .toList();
+
+    if (emptyPlotIds.isEmpty) return null;
+
+    var state = addCurrency(Currency.gp, -gpCost);
+
+    for (final plotId in emptyPlotIds) {
+      // Apply compost if selected and available
+      if (compost != null) {
+        var applied = 0;
+        for (var i = 0; i < compostCount; i++) {
+          if (state.inventory.countOfItem(compost) < 1) break;
+          state = state.applyCompost(plotId, compost);
+          applied++;
+        }
+        if (applied == 0 && compostCount > 0) {
+          // No compost left, skip compost for remaining plots
+        }
+      }
+
+      // Plant crop if seeds are available
+      final seed = state.registries.items.byId(crop.seedId);
+      if (state.inventory.countOfItem(seed) < crop.seedCost) break;
+      state = state.plantCrop(plotId, crop);
+    }
+
+    return state;
+  }
+
   /// Clears a farming plot, destroying any growing crop and compost.
   GlobalState clearPlot(MelvorId plotId) {
     final newPlotStates = Map<MelvorId, PlotState>.from(plotStates)

--- a/logic/test/data/farming_test.dart
+++ b/logic/test/data/farming_test.dart
@@ -531,4 +531,353 @@ void main() {
       expect(state.plotStates[plotId], isNull);
     });
   });
+
+  group('harvestAllCrops', () {
+    late FarmingCrop allotmentCrop;
+    late FarmingCategory allotmentCategory;
+    late List<FarmingPlot> allotmentPlots;
+
+    setUpAll(() {
+      allotmentCategory = testRegistries.farmingCategories.firstWhere(
+        (c) => c.name == 'Allotments',
+      );
+      allotmentCrop = testRegistries.farming
+          .cropsForCategory(allotmentCategory.id)
+          .firstWhere((c) => c.level == 1);
+      // Use all allotment plots (we'll manually unlock them in tests)
+      allotmentPlots = testRegistries.farming.plotsForCategory(
+        allotmentCategory.id,
+      );
+    });
+
+    /// Creates a state with all allotment plots unlocked.
+    GlobalState stateWithUnlockedPlots({int gp = 5000}) {
+      final base = GlobalState.empty(testRegistries);
+      return base.copyWith(
+        currencies: {Currency.gp: gp},
+        unlockedPlots: {
+          ...base.unlockedPlots,
+          ...{for (final p in allotmentPlots) p.id},
+        },
+      );
+    }
+
+    test('harvests all ready plots and deducts GP', () {
+      final random = Random(42);
+      final plotId1 = allotmentPlots[0].id;
+      final plotId2 = allotmentPlots[1].id;
+
+      var state = stateWithUnlockedPlots();
+      state = state.copyWith(
+        plotStates: {
+          plotId1: PlotState(
+            cropId: allotmentCrop.id,
+            growthTicksRemaining: 0,
+            compostItems: [testCompost(compostValue: 50)],
+          ),
+          plotId2: PlotState(
+            cropId: allotmentCrop.id,
+            growthTicksRemaining: 0,
+            compostItems: [testCompost(compostValue: 50)],
+          ),
+        },
+      );
+
+      final result = state.harvestAllCrops(allotmentCategory.id, random);
+      expect(result, isNotNull);
+
+      final (newState, changes) = result!;
+      // GP deducted
+      expect(newState.gp, 3000);
+      // Both plots cleared
+      expect(newState.plotStates[plotId1], isNull);
+      expect(newState.plotStates[plotId2], isNull);
+      // Got products
+      final product = testRegistries.items.byId(allotmentCrop.productId);
+      expect(newState.inventory.countOfItem(product), greaterThan(0));
+      // Changes are not empty
+      expect(changes.isEmpty, isFalse);
+    });
+
+    test('returns null when cannot afford GP', () {
+      final random = Random(42);
+      final plotId = allotmentPlots[0].id;
+
+      var state = stateWithUnlockedPlots(gp: 1999);
+      state = state.copyWith(
+        plotStates: {
+          plotId: PlotState(cropId: allotmentCrop.id, growthTicksRemaining: 0),
+        },
+      );
+
+      final result = state.harvestAllCrops(allotmentCategory.id, random);
+      expect(result, isNull);
+    });
+
+    test('returns null when no plots are ready', () {
+      final random = Random(42);
+      final plotId = allotmentPlots[0].id;
+
+      var state = stateWithUnlockedPlots();
+      state = state.copyWith(
+        plotStates: {
+          // Growing, not ready
+          plotId: PlotState(
+            cropId: allotmentCrop.id,
+            growthTicksRemaining: 100,
+          ),
+        },
+      );
+
+      final result = state.harvestAllCrops(allotmentCategory.id, random);
+      expect(result, isNull);
+    });
+
+    test('only harvests plots in the specified category', () {
+      final random = Random(42);
+      final allotmentPlotId = allotmentPlots[0].id;
+
+      // Get a tree category plot
+      final treeCategory = testRegistries.farmingCategories.firstWhere(
+        (c) => c.name == 'Trees',
+      );
+      final treePlots = testRegistries.farming.plotsForCategory(
+        treeCategory.id,
+      );
+      final treePlotId = treePlots.first.id;
+
+      final treeCrops = testRegistries.farming.cropsForCategory(treeCategory.id)
+        ..sort((a, b) => a.level.compareTo(b.level));
+      final treeCrop = treeCrops.first;
+
+      var state = stateWithUnlockedPlots();
+      state = state.copyWith(
+        unlockedPlots: {...state.unlockedPlots, treePlotId},
+        plotStates: {
+          allotmentPlotId: PlotState(
+            cropId: allotmentCrop.id,
+            growthTicksRemaining: 0,
+            compostItems: [testCompost(compostValue: 50)],
+          ),
+          treePlotId: PlotState(
+            cropId: treeCrop.id,
+            growthTicksRemaining: 0,
+            compostItems: [testCompost(compostValue: 50)],
+          ),
+        },
+      );
+
+      // Harvest only allotments
+      final result = state.harvestAllCrops(allotmentCategory.id, random);
+      expect(result, isNotNull);
+
+      final (newState, _) = result!;
+      // Allotment plot cleared
+      expect(newState.plotStates[allotmentPlotId], isNull);
+      // Tree plot still ready
+      expect(newState.plotStates[treePlotId]?.isReadyToHarvest, isTrue);
+    });
+  });
+
+  group('plantAllCrops', () {
+    late FarmingCrop allotmentCrop;
+    late FarmingCategory allotmentCategory;
+    late List<FarmingPlot> allotmentPlots;
+
+    setUpAll(() {
+      allotmentCategory = testRegistries.farmingCategories.firstWhere(
+        (c) => c.name == 'Allotments',
+      );
+      allotmentCrop = testRegistries.farming
+          .cropsForCategory(allotmentCategory.id)
+          .firstWhere((c) => c.level == 1);
+      allotmentPlots = testRegistries.farming.plotsForCategory(
+        allotmentCategory.id,
+      );
+    });
+
+    /// Creates a state with all allotment plots unlocked.
+    GlobalState stateWithUnlockedPlots({int gp = 10000}) {
+      final base = GlobalState.empty(testRegistries);
+      return base.copyWith(
+        currencies: {Currency.gp: gp},
+        unlockedPlots: {
+          ...base.unlockedPlots,
+          ...{for (final p in allotmentPlots) p.id},
+        },
+      );
+    }
+
+    test('plants in all empty plots and deducts GP', () {
+      final seed = testRegistries.items.byId(allotmentCrop.seedId);
+
+      var state = stateWithUnlockedPlots();
+      state = state.copyWith(
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(seed, count: allotmentCrop.seedCost * 20),
+        ]),
+      );
+
+      final result = state.plantAllCrops(
+        allotmentCategory.id,
+        allotmentCrop,
+        null,
+        0,
+      );
+      expect(result, isNotNull);
+
+      final newState = result!;
+      // GP deducted (5000 base, no compost)
+      expect(newState.gp, 5000);
+
+      // All allotment plots should have crops
+      for (final plot in allotmentPlots) {
+        final ps = newState.plotStates[plot.id];
+        expect(ps, isNotNull, reason: 'Plot ${plot.id} should have a crop');
+        expect(ps!.isGrowing, isTrue);
+        expect(ps.cropId, allotmentCrop.id);
+      }
+    });
+
+    test('returns null when cannot afford GP', () {
+      final seed = testRegistries.items.byId(allotmentCrop.seedId);
+
+      var state = stateWithUnlockedPlots(gp: 4999);
+      state = state.copyWith(
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(seed, count: allotmentCrop.seedCost * 10),
+        ]),
+      );
+
+      final result = state.plantAllCrops(
+        allotmentCategory.id,
+        allotmentCrop,
+        null,
+        0,
+      );
+      expect(result, isNull);
+    });
+
+    test('returns null when no empty plots', () {
+      var state = stateWithUnlockedPlots();
+      state = state.copyWith(
+        plotStates: {
+          // Fill all plots with growing crops
+          for (final plot in allotmentPlots)
+            plot.id: PlotState(
+              cropId: allotmentCrop.id,
+              growthTicksRemaining: 100,
+            ),
+        },
+      );
+
+      final result = state.plantAllCrops(
+        allotmentCategory.id,
+        allotmentCrop,
+        null,
+        0,
+      );
+      expect(result, isNull);
+    });
+
+    test('stops planting when seeds run out', () {
+      final seed = testRegistries.items.byId(allotmentCrop.seedId);
+
+      // Only enough seeds for 1 plot
+      var state = stateWithUnlockedPlots();
+      state = state.copyWith(
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(seed, count: allotmentCrop.seedCost),
+        ]),
+      );
+
+      final result = state.plantAllCrops(
+        allotmentCategory.id,
+        allotmentCrop,
+        null,
+        0,
+      );
+      expect(result, isNotNull);
+
+      final newState = result!;
+      // Only one plot should be planted
+      final plantedCount = allotmentPlots.where((plot) {
+        final ps = newState.plotStates[plot.id];
+        return ps != null && ps.isGrowing;
+      }).length;
+      expect(plantedCount, 1);
+    });
+
+    test('plants with compost and deducts extra GP', () {
+      final seed = testRegistries.items.byId(allotmentCrop.seedId);
+      final compost = Item.test('Compost', gp: 50, compostValue: 10);
+
+      var state = stateWithUnlockedPlots();
+      state = state.copyWith(
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(seed, count: allotmentCrop.seedCost * 20),
+          ItemStack(compost, count: 100),
+        ]),
+      );
+
+      final result = state.plantAllCrops(
+        allotmentCategory.id,
+        allotmentCrop,
+        compost,
+        5,
+      );
+      expect(result, isNotNull);
+
+      final newState = result!;
+      // GP deducted (5000 + 2000 for compost = 7000)
+      expect(newState.gp, 10000 - 7000);
+
+      // All initial allotment plots should have crops with compost
+      for (final plot in allotmentPlots) {
+        final ps = newState.plotStates[plot.id];
+        expect(ps, isNotNull);
+        expect(ps!.isGrowing, isTrue);
+        expect(ps.compostApplied, 50); // 5 x 10
+      }
+    });
+
+    test('skips compost when it runs out but still plants', () {
+      final seed = testRegistries.items.byId(allotmentCrop.seedId);
+      final compost = Item.test('Compost', gp: 50, compostValue: 10);
+
+      // Only enough compost for 1 plot (5 per plot)
+      var state = stateWithUnlockedPlots();
+      state = state.copyWith(
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(seed, count: allotmentCrop.seedCost * 20),
+          ItemStack(compost, count: 5),
+        ]),
+      );
+
+      final result = state.plantAllCrops(
+        allotmentCategory.id,
+        allotmentCrop,
+        compost,
+        5,
+      );
+      expect(result, isNotNull);
+
+      final newState = result!;
+      // Count plots with and without compost
+      var withCompost = 0;
+      var withoutCompost = 0;
+      for (final plot in allotmentPlots) {
+        final ps = newState.plotStates[plot.id];
+        if (ps != null && ps.isGrowing) {
+          if (ps.compostApplied > 0) {
+            withCompost++;
+          } else {
+            withoutCompost++;
+          }
+        }
+      }
+      expect(withCompost, 1);
+      expect(withoutCompost, greaterThan(0));
+    });
+  });
 }

--- a/ui/lib/src/logic/redux_actions.dart
+++ b/ui/lib/src/logic/redux_actions.dart
@@ -744,6 +744,46 @@ class ClearPlotAction extends ReduxAction<GlobalState> {
   }
 }
 
+/// Harvests all ready crops in a category (costs 2,000 GP).
+class HarvestAllCropsAction extends ReduxAction<GlobalState> {
+  HarvestAllCropsAction({required this.categoryId});
+  final MelvorId categoryId;
+
+  @override
+  GlobalState? reduce() {
+    final random = Random();
+    final result = state.harvestAllCrops(categoryId, random);
+    if (result == null) return null;
+
+    final (newState, changes) = result;
+    if (!changes.isEmpty) {
+      toastService.showToast(changes);
+    }
+
+    return newState;
+  }
+}
+
+/// Plants a crop in all empty plots of a category (costs 5,000+ GP).
+class PlantAllCropsAction extends ReduxAction<GlobalState> {
+  PlantAllCropsAction({
+    required this.categoryId,
+    required this.crop,
+    this.compost,
+    this.compostCount = 0,
+  });
+
+  final MelvorId categoryId;
+  final FarmingCrop crop;
+  final Item? compost;
+  final int compostCount;
+
+  @override
+  GlobalState? reduce() {
+    return state.plantAllCrops(categoryId, crop, compost, compostCount);
+  }
+}
+
 /// Sets the player's attack style for combat XP distribution.
 class SetAttackStyleAction extends ReduxAction<GlobalState> {
   SetAttackStyleAction({required this.attackStyle});

--- a/ui/lib/src/screens/farming.dart
+++ b/ui/lib/src/screens/farming.dart
@@ -96,14 +96,55 @@ class _CategorySection extends StatelessWidget {
       if (lockedWithoutLevel.isNotEmpty) lockedWithoutLevel.first,
     ]..sort((a, b) => a.level.compareTo(b.level));
 
+    // Count ready and empty plots for bulk action buttons
+    final readyCount = unlockedPlots.where((plot) {
+      final ps = state.plotStates[plot.id];
+      return ps != null && ps.isReadyToHarvest;
+    }).length;
+    final emptyCount = unlockedPlots.where((plot) {
+      final ps = state.plotStates[plot.id];
+      return ps == null || ps.isEmpty;
+    }).length;
+
+    final canAffordHarvest = state.gp >= 2000;
+    final canAffordPlant = state.gp >= 5000;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(
           padding: const EdgeInsets.symmetric(vertical: 8),
-          child: Text(
-            category.name,
-            style: Theme.of(context).textTheme.titleLarge,
+          child: Row(
+            children: [
+              Text(
+                category.name,
+                style: Theme.of(context).textTheme.titleLarge,
+              ),
+              const Spacer(),
+              FilledButton.tonal(
+                onPressed: readyCount > 0 && canAffordHarvest
+                    ? () => context.dispatch(
+                        HarvestAllCropsAction(categoryId: category.id),
+                      )
+                    : null,
+                child: Text('Harvest All ($readyCount)'),
+              ),
+              const SizedBox(width: 8),
+              FilledButton.tonal(
+                onPressed: emptyCount > 0 && canAffordPlant
+                    ? () => showDialog<void>(
+                        context: context,
+                        builder: (dialogContext) => _PlantAllDialog(
+                          category: category,
+                          state: state,
+                          emptyCount: emptyCount,
+                          outerContext: context,
+                        ),
+                      )
+                    : null,
+                child: Text('Plant All ($emptyCount)'),
+              ),
+            ],
           ),
         ),
         Wrap(
@@ -508,6 +549,28 @@ class _CompostOption {
   int get harvestBonus => (item?.harvestBonus ?? 0) * count;
 }
 
+List<_CompostOption> _getCompostOptions(GlobalState state) {
+  final registries = state.registries;
+  final inventory = state.inventory;
+  final options = <_CompostOption>[
+    const _CompostOption(item: null, count: 0, available: 0),
+  ];
+
+  for (final item in registries.items.all) {
+    final compostValue = item.compostValue;
+    if (compostValue == null || compostValue == 0) continue;
+
+    final available = inventory.countOfItem(item);
+    if (compostValue <= 10) {
+      options.add(_CompostOption(item: item, count: 5, available: available));
+    } else {
+      options.add(_CompostOption(item: item, count: 1, available: available));
+    }
+  }
+
+  return options;
+}
+
 /// Dialog for selecting a crop to plant with optional compost.
 class _CropSelectionDialog extends StatefulWidget {
   const _CropSelectionDialog({
@@ -528,32 +591,6 @@ class _CropSelectionDialog extends StatefulWidget {
 
 class _CropSelectionDialogState extends State<_CropSelectionDialog> {
   int _selectedCompostIndex = 0;
-
-  List<_CompostOption> _getCompostOptions() {
-    final registries = widget.state.registries;
-    final inventory = widget.state.inventory;
-    final options = <_CompostOption>[
-      const _CompostOption(item: null, count: 0, available: 0),
-    ];
-
-    // Find compost items in registry
-    for (final item in registries.items.all) {
-      final compostValue = item.compostValue;
-      if (compostValue == null || compostValue == 0) continue;
-
-      final available = inventory.countOfItem(item);
-
-      // Regular compost (10%): offer 5x to get 50% success boost
-      // Weird Gloop (50%): offer 1x to get 50% success boost
-      if (compostValue <= 10) {
-        options.add(_CompostOption(item: item, count: 5, available: available));
-      } else {
-        options.add(_CompostOption(item: item, count: 1, available: available));
-      }
-    }
-
-    return options;
-  }
 
   int _getSuccessChance(int compostValue) {
     // Base success chance is 50%, compost adds to it
@@ -578,7 +615,7 @@ class _CropSelectionDialogState extends State<_CropSelectionDialog> {
       return seedCount >= crop.seedCost;
     }).toList()..sort((a, b) => a.level.compareTo(b.level));
 
-    final compostOptions = _getCompostOptions();
+    final compostOptions = _getCompostOptions(widget.state);
     final selectedCompost = compostOptions[_selectedCompostIndex];
     final compostValue =
         (selectedCompost.item?.compostValue ?? 0) * selectedCompost.count;
@@ -701,6 +738,198 @@ class _CropSelectionDialogState extends State<_CropSelectionDialog> {
     // Then plant the crop
     outerContext.dispatch(PlantCropAction(plotId: widget.plot.id, crop: crop));
 
+    Navigator.of(context).pop();
+  }
+}
+
+/// Dialog for selecting a crop to plant in all empty plots.
+class _PlantAllDialog extends StatefulWidget {
+  const _PlantAllDialog({
+    required this.category,
+    required this.state,
+    required this.emptyCount,
+    required this.outerContext,
+  });
+
+  final FarmingCategory category;
+  final GlobalState state;
+  final int emptyCount;
+  final BuildContext outerContext;
+
+  @override
+  State<_PlantAllDialog> createState() => _PlantAllDialogState();
+}
+
+class _PlantAllDialogState extends State<_PlantAllDialog> {
+  int _selectedCompostIndex = 0;
+
+  int _getSuccessChance(int compostValue) {
+    return (50 + compostValue).clamp(0, 100);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final registries = widget.state.registries;
+    final farmingLevel = widget.state.skillState(Skill.farming).skillLevel;
+
+    final allCrops = registries.farming.cropsForCategory(widget.category.id);
+    final availableCrops = allCrops.where((crop) {
+      if (crop.level > farmingLevel) return false;
+      final seed = registries.items.byId(crop.seedId);
+      final seedCount = widget.state.inventory.countOfItem(seed);
+      return seedCount >= crop.seedCost;
+    }).toList()..sort((a, b) => a.level.compareTo(b.level));
+
+    final compostOptions = _getCompostOptions(widget.state);
+    final selectedCompost = compostOptions[_selectedCompostIndex];
+    final compostValue =
+        (selectedCompost.item?.compostValue ?? 0) * selectedCompost.count;
+    final successChance = _getSuccessChance(compostValue);
+
+    final gpCost = 5000 + (selectedCompost.item != null ? 2000 : 0);
+    final canAfford = widget.state.gp >= gpCost;
+    final gpColor = canAfford ? Style.successColor : Style.errorColor;
+
+    // Total compost needed for all empty plots
+    final totalCompostNeeded = selectedCompost.count * widget.emptyCount;
+
+    return AlertDialog(
+      title: const Text('Plant All'),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // GP cost
+            Row(
+              children: [
+                const Text('Cost: '),
+                Text(
+                  '${gpCost}gp',
+                  style: TextStyle(color: gpColor, fontWeight: FontWeight.bold),
+                ),
+                Text(
+                  ' (have ${widget.state.gp})',
+                  style: const TextStyle(color: Style.textColorSecondary),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            // Compost selection
+            if (compostOptions.length > 1) ...[
+              const Text('Compost:'),
+              const SizedBox(height: 4),
+              SegmentedButton<int>(
+                segments: [
+                  for (var i = 0; i < compostOptions.length; i++)
+                    ButtonSegment(
+                      value: i,
+                      label: _buildCompostLabel(compostOptions[i]),
+                    ),
+                ],
+                selected: {_selectedCompostIndex},
+                onSelectionChanged: (selected) {
+                  setState(() => _selectedCompostIndex = selected.first);
+                },
+              ),
+              const SizedBox(height: 8),
+              Text('Success chance: $successChance%'),
+              if (selectedCompost.harvestBonus > 0)
+                Text('Harvest bonus: +${selectedCompost.harvestBonus}%'),
+              if (selectedCompost.item != null) ...[
+                Text(
+                  'Need $totalCompostNeeded ${selectedCompost.item!.name} '
+                  '(have ${selectedCompost.available})',
+                  style: TextStyle(
+                    color: selectedCompost.available >= totalCompostNeeded
+                        ? null
+                        : Style.errorColor,
+                  ),
+                ),
+              ],
+              const Divider(),
+            ],
+            // Crop list
+            Flexible(
+              child: availableCrops.isEmpty
+                  ? const Text(
+                      'No crops available. You need seeds and the required '
+                      'farming level to plant crops.',
+                    )
+                  : ListView.builder(
+                      shrinkWrap: true,
+                      itemCount: availableCrops.length,
+                      itemBuilder: (context, index) {
+                        final crop = availableCrops[index];
+                        final seed = registries.items.byId(crop.seedId);
+                        final product = registries.items.byId(crop.productId);
+                        final seedCount = widget.state.inventory.countOfItem(
+                          seed,
+                        );
+                        final totalSeedsNeeded =
+                            crop.seedCost * widget.emptyCount;
+                        final plotsPlantable = seedCount ~/ crop.seedCost;
+
+                        return ListTile(
+                          leading: ItemImage(item: product, size: 40),
+                          title: Text(product.name),
+                          subtitle: Text(
+                            'Level ${crop.level} · '
+                            '${crop.seedCost} seeds each · '
+                            'need $totalSeedsNeeded '
+                            '(have $seedCount, '
+                            'enough for $plotsPlantable)',
+                          ),
+                          enabled: canAfford,
+                          onTap: canAfford
+                              ? () => _plantAll(crop, selectedCompost)
+                              : null,
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCompostLabel(_CompostOption option) {
+    if (option.item == null) {
+      return const Text('None', style: TextStyle(fontSize: 12));
+    }
+
+    final countColor = option.hasEnough ? null : Style.errorColor;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          '${option.count}',
+          style: TextStyle(fontSize: 12, color: countColor),
+        ),
+        const SizedBox(width: 4),
+        ItemImage(item: option.item!, size: 16),
+      ],
+    );
+  }
+
+  void _plantAll(FarmingCrop crop, _CompostOption compostOption) {
+    widget.outerContext.dispatch(
+      PlantAllCropsAction(
+        categoryId: widget.category.id,
+        crop: crop,
+        compost: compostOption.item,
+        compostCount: compostOption.count,
+      ),
+    );
     Navigator.of(context).pop();
   }
 }


### PR DESCRIPTION
## Summary
- Add **Harvest All** button (2,000 GP) per farming category that harvests all ready plots and shows a merged toast
- Add **Plant All** button (5,000 GP base, +2,000 with compost) that opens a dialog to select crop/compost, then plants in all empty plots
- Buttons show count of applicable plots and are disabled when no plots are ready/empty or GP is insufficient
- Plant All dialog shows GP cost with affordability coloring, compost selection, total compost/seed requirements
- Gracefully handles partial resources (stops when seeds run out, skips compost when it runs out)

## Test plan
- [x] `dart test -r failures-only` (logic) — 28 farming tests pass including 10 new tests
- [x] `dart format .` — no formatting issues
- [x] `dart analyze --fatal-infos` — no new issues
- [x] `npx cspell` — no spelling issues
- [ ] Manual: verify Harvest All button harvests all ready plots and deducts GP
- [ ] Manual: verify Plant All dialog shows correct costs and plants in empty plots
- [ ] Manual: verify buttons are disabled when GP is insufficient or no plots available