### PR TITLE
feat: shop badge + purchase dialog for farming compost & summoning shards

### DIFF
--- a/ui/lib/src/screens/farming.dart
+++ b/ui/lib/src/screens/farming.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart' hide Action;
-import 'package:go_router/go_router.dart';
 import 'package:logic/logic.dart';
 import 'package:ui/src/logic/redux_actions.dart';
 import 'package:ui/src/widgets/context_extensions.dart';
@@ -8,6 +7,7 @@ import 'package:ui/src/widgets/game_scaffold.dart';
 import 'package:ui/src/widgets/item_count_badge_cell.dart';
 import 'package:ui/src/widgets/item_image.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
+import 'package:ui/src/widgets/shard_purchase_dialog.dart';
 import 'package:ui/src/widgets/skill_fab.dart';
 import 'package:ui/src/widgets/skill_image.dart';
 import 'package:ui/src/widgets/skill_overflow_menu.dart';
@@ -81,7 +81,14 @@ class _CompostIndicators extends StatelessWidget {
         children: [
           for (final item in compostItems)
             GestureDetector(
-              onTap: () => context.go('/shop'),
+              onTap: () {
+                final purchases = registries.shop.purchasesContainingItem(
+                  item.id,
+                );
+                if (purchases.isNotEmpty) {
+                  showShardPurchaseDialog(context, item);
+                }
+              },
               child: ItemCountBadgeCell(
                 item: item,
                 count: state.inventory.countOfItem(item),

--- a/ui/lib/src/screens/summoning.dart
+++ b/ui/lib/src/screens/summoning.dart
@@ -630,6 +630,7 @@ class _SummoningActionDisplay extends StatelessWidget {
       buttonText: 'Create',
       showRecycleBadge: true,
       effectText: effectText,
+      showInputShopBadge: true,
       onStart: onStart,
       onInputItemTap: (item) => _onShardTap(context, item),
     );

--- a/ui/lib/src/widgets/item_count_badge_cell.dart
+++ b/ui/lib/src/widgets/item_count_badge_cell.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:logic/logic.dart';
+import 'package:ui/src/widgets/cached_image.dart';
 import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/count_badge_cell.dart';
 import 'package:ui/src/widgets/item_image.dart';
@@ -59,10 +60,9 @@ class ItemCountBadgeCell extends StatelessWidget {
             const Positioned(
               top: 1,
               left: 1,
-              child: Icon(
-                Icons.shopping_cart,
+              child: CachedImage(
+                assetPath: 'assets/media/main/shop_header.png',
                 size: 14,
-                color: Style.badgeTextColor,
               ),
             ),
         ],
@@ -80,6 +80,7 @@ class ItemCountBadgesRow extends StatelessWidget {
   const ItemCountBadgesRow._({
     required this.items,
     required this.showInventory,
+    this.showShopBadge = false,
     this.onItemTap,
     super.key,
   });
@@ -87,11 +88,13 @@ class ItemCountBadgesRow extends StatelessWidget {
   /// Creates a row showing required item counts (no inventory comparison).
   const ItemCountBadgesRow.required({
     required Map<MelvorId, int> items,
+    bool showShopBadge = false,
     void Function(Item item)? onItemTap,
     Key? key,
   }) : this._(
          items: items,
          showInventory: false,
+         showShopBadge: showShopBadge,
          onItemTap: onItemTap,
          key: key,
        );
@@ -99,17 +102,20 @@ class ItemCountBadgesRow extends StatelessWidget {
   /// Creates a row showing inventory counts with color-coded borders.
   const ItemCountBadgesRow.inventory({
     required Map<MelvorId, int> items,
+    bool showShopBadge = false,
     void Function(Item item)? onItemTap,
     Key? key,
   }) : this._(
          items: items,
          showInventory: true,
+         showShopBadge: showShopBadge,
          onItemTap: onItemTap,
          key: key,
        );
 
   final Map<MelvorId, int> items;
   final bool showInventory;
+  final bool showShopBadge;
 
   /// Optional callback when an item is tapped.
   final void Function(Item item)? onItemTap;
@@ -132,6 +138,10 @@ class ItemCountBadgesRow extends StatelessWidget {
         final item = state.registries.items.byId(entry.key);
         final requiredCount = entry.value;
 
+        final itemHasShopBadge =
+            showShopBadge &&
+            state.registries.shop.purchasesContainingItem(item.id).isNotEmpty;
+
         Widget cell;
         if (showInventory) {
           final inventoryCount = state.inventory.countOfItem(item);
@@ -140,9 +150,14 @@ class ItemCountBadgesRow extends StatelessWidget {
             item: item,
             count: inventoryCount,
             hasEnough: hasEnough,
+            showShopBadge: itemHasShopBadge,
           );
         } else {
-          cell = ItemCountBadgeCell(item: item, count: requiredCount);
+          cell = ItemCountBadgeCell(
+            item: item,
+            count: requiredCount,
+            showShopBadge: itemHasShopBadge,
+          );
         }
 
         if (onItemTap != null) {

--- a/ui/lib/src/widgets/production_action_display.dart
+++ b/ui/lib/src/widgets/production_action_display.dart
@@ -38,6 +38,7 @@ class ProductionActionDisplay extends StatelessWidget {
     required this.showRecycleBadge,
     this.skillLevel,
     this.effectText,
+    this.showInputShopBadge = false,
     this.onInputItemTap,
     super.key,
   });
@@ -53,6 +54,9 @@ class ProductionActionDisplay extends StatelessWidget {
 
   /// Optional effect text shown below the action name (e.g., for summoning).
   final String? effectText;
+
+  /// Whether to show shop badge icons on input items that are purchasable.
+  final bool showInputShopBadge;
 
   /// Optional callback when an input item is tapped
   /// (e.g., for purchase dialog).
@@ -260,6 +264,7 @@ class ProductionActionDisplay extends StatelessWidget {
               else
                 ItemCountBadgesRow.required(
                   items: inputs,
+                  showShopBadge: showInputShopBadge,
                   onItemTap: onInputItemTap,
                 ),
             ],
@@ -284,6 +289,7 @@ class ProductionActionDisplay extends StatelessWidget {
               else
                 ItemCountBadgesRow.inventory(
                   items: inputs,
+                  showShopBadge: showInputShopBadge,
                   onItemTap: onInputItemTap,
                 ),
             ],


### PR DESCRIPTION
## Summary
- Farming compost indicators now open a purchase dialog on tap instead of navigating to the shop page
- Summoning tablet inputs show a shop badge icon on purchasable shards (marks are correctly excluded via `purchasesContainingItem` check)
- Shop badge icon uses the `shop_header.png` asset instead of `Icons.shopping_cart`
- Added `showShopBadge` param to `ItemCountBadgesRow` and `showInputShopBadge` to `ProductionActionDisplay` so any production skill can opt in

## Test plan
- [x] `flutter test` — all 164 tests pass
- [x] `dart format .` / `dart analyze --fatal-infos` — clean
- [ ] Verify farming compost cells show shop icon and open purchase dialog on tap
- [ ] Verify summoning tablet inputs show shop icon on shards but not marks