### PR TITLE
fix: solver crash on consuming skill prerequisites and add --help

### DIFF
--- a/logic/bin/solver.dart
+++ b/logic/bin/solver.dart
@@ -90,6 +90,12 @@ final _parser = ArgParser()
     help:
         'Write the plan to a JSON file (e.g., plan.json). '
         'Implies --no-execute unless -v is also specified.',
+  )
+  ..addFlag(
+    'help',
+    abbr: 'h',
+    help: 'Show usage information',
+    negatable: false,
   );
 
 // ---------------------------------------------------------------------------
@@ -160,6 +166,13 @@ class SolvedPlan {
 
 void main(List<String> args) async {
   final results = _parser.parse(args);
+
+  if (results['help'] as bool) {
+    print('Usage: dart run bin/solver.dart [options] [goal_credits]');
+    print('');
+    print(_parser.usage);
+    return;
+  }
 
   final registries = await loadRegistries();
 

--- a/logic/lib/src/solver/candidates/macro_candidate.dart
+++ b/logic/lib/src/solver/candidates/macro_candidate.dart
@@ -305,6 +305,14 @@ class TrainSkillUntil extends MacroCandidate {
       return MacroCannotPlan('No unlocked action for ${skill.name}');
     }
 
+    // Check if the action can actually be started (has required inputs).
+    final action = state.registries.actionById(bestAction);
+    if (!state.canStartAction(action)) {
+      return MacroCannotPlan(
+        'Cannot start ${action.name} for ${skill.name}: missing inputs',
+      );
+    }
+
     // Switch to that action (if not already on it)
     var currentState = state;
     if (state.currentActionId != bestAction) {

--- a/logic/test/solver/macro_candidate_test.dart
+++ b/logic/test/solver/macro_candidate_test.dart
@@ -733,6 +733,40 @@ void main() {
           expect(macro1.dedupeKey, isNot(equals(macro2.dedupeKey)));
         });
       });
+
+      group('plan', () {
+        MacroPlanContext makeContext(GlobalState state, {Goal? goal}) {
+          return MacroPlanContext(
+            state: state,
+            goal: goal ?? const ReachSkillLevelGoal(Skill.woodcutting, 10),
+            boundaries: const {},
+          );
+        }
+
+        test(
+          'returns MacroCannotPlan when best action needs missing inputs',
+          () {
+            // Smithing is a consuming skill - Bronze Dagger needs Bronze Bar.
+            // With no bars in inventory, plan() should return MacroCannotPlan
+            // instead of crashing.
+            final state = GlobalState.empty(testRegistries);
+            final context = makeContext(
+              state,
+              goal: const ReachSkillLevelGoal(Skill.smithing, 10),
+            );
+            const macro = TrainSkillUntil(
+              Skill.smithing,
+              StopAtNextBoundary(Skill.smithing),
+            );
+
+            final result = macro.plan(context);
+
+            expect(result, isA<MacroCannotPlan>());
+            final cannotPlan = result as MacroCannotPlan;
+            expect(cannotPlan.reason, contains('missing inputs'));
+          },
+        );
+      });
     });
 
     group('AcquireItem', () {


### PR DESCRIPTION
## Summary
- **Fix solver crash**: `TrainSkillUntil.plan()` crashed with an unhandled exception when the best action for a skill required inputs not in inventory (e.g., smithing as a prerequisite for fletching needed Bronze Bars). Now checks `canStartAction()` and returns `MacroCannotPlan` instead of throwing, letting the outer planner skip unviable candidates gracefully.
- **Add `--help`/`-h` flag** to the solver CLI.

Before: `dart run bin/solver.dart -m "Fletching=30"` crashed with `Exception: Cannot start Bronze Dagger: Need 1 Bronze Bar`.
After: Fletching=30 solves successfully (sources logs from woodcutting, makes shortbows/longbows).

## Test plan
- [x] `dart test -r failures-only` passes (2247 tests)
- [x] `dart run bin/solver.dart` (default 100 GP goal) still works
- [x] `dart run bin/solver.dart -m "Fletching=30"` now solves instead of crashing
- [x] `dart run bin/solver.dart --help` prints usage info