### PR TITLE
fix: show item images in crate open result dialog

### DIFF
--- a/logic/lib/src/types/open_result.dart
+++ b/logic/lib/src/types/open_result.dart
@@ -1,3 +1,4 @@
+import 'package:logic/src/data/items.dart';
 import 'package:logic/src/types/inventory.dart';
 import 'package:meta/meta.dart';
 
@@ -14,8 +15,8 @@ class OpenResult {
   final int openedCount;
 
   /// The combined drops from all opened items.
-  /// Maps item name to total count received.
-  final Map<String, int> drops;
+  /// Maps item to total count received.
+  final Map<Item, int> drops;
 
   /// Error message if opening stopped early (e.g., 'Inventory full').
   /// Null if all requested items were opened successfully.
@@ -26,8 +27,8 @@ class OpenResult {
 
   /// Adds a drop to the result, returning a new OpenResult.
   OpenResult addDrop(ItemStack drop) {
-    final newDrops = Map<String, int>.from(drops);
-    newDrops[drop.item.name] = (newDrops[drop.item.name] ?? 0) + drop.count;
+    final newDrops = Map<Item, int>.from(drops);
+    newDrops[drop.item] = (newDrops[drop.item] ?? 0) + drop.count;
     return OpenResult(
       openedCount: openedCount + 1,
       drops: newDrops,

--- a/logic/test/state_test.dart
+++ b/logic/test/state_test.dart
@@ -742,21 +742,11 @@ void main() {
 
       // Got exactly one type of drop (feathers or raw chicken)
       expect(result.drops.length, 1);
-      final dropName = result.drops.keys.first;
-      expect(dropName == 'Feathers' || dropName == 'Raw Chicken', isTrue);
+      final dropItem = result.drops.keys.first;
+      expect(dropItem == feathers || dropItem == rawChicken, isTrue);
 
       // The drop is in inventory
-      if (dropName == 'Feathers') {
-        expect(
-          newState.inventory.countOfItem(feathers),
-          result.drops[dropName],
-        );
-      } else {
-        expect(
-          newState.inventory.countOfItem(rawChicken),
-          result.drops[dropName],
-        );
-      }
+      expect(newState.inventory.countOfItem(dropItem), result.drops[dropItem]);
     });
 
     test('opens multiple items and combines drops', () {
@@ -786,8 +776,8 @@ void main() {
       expect(result.drops.isNotEmpty, isTrue);
 
       // Total drops in result match inventory
-      final feathersInResult = result.drops['Feathers'] ?? 0;
-      final chickenInResult = result.drops['Raw Chicken'] ?? 0;
+      final feathersInResult = result.drops[feathers] ?? 0;
+      final chickenInResult = result.drops[rawChicken] ?? 0;
       expect(newState.inventory.countOfItem(feathers), feathersInResult);
       expect(newState.inventory.countOfItem(rawChicken), chickenInResult);
     });

--- a/ui/lib/src/widgets/item_count_row.dart
+++ b/ui/lib/src/widgets/item_count_row.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:logic/logic.dart';
+import 'package:ui/src/widgets/item_image.dart';
+
+/// A widget that displays an item count with icon and name.
+///
+/// Example: `100 [icon] Lobster`
+class ItemCountRow extends StatelessWidget {
+  const ItemCountRow({
+    required this.item,
+    required this.count,
+    this.countColor,
+    super.key,
+  });
+
+  /// The item to display.
+  final Item item;
+
+  /// The count of items.
+  final int count;
+
+  /// Optional color for the count text.
+  final Color? countColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 16, bottom: 4),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            approximateCountString(count),
+            style: countColor != null ? TextStyle(color: countColor) : null,
+          ),
+          const SizedBox(width: 4),
+          ItemImage(item: item, size: 16),
+          const SizedBox(width: 4),
+          Flexible(child: Text(item.name)),
+        ],
+      ),
+    );
+  }
+}

--- a/ui/lib/src/widgets/open_result_dialog.dart
+++ b/ui/lib/src/widgets/open_result_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:logic/logic.dart';
+import 'package:ui/src/widgets/item_count_row.dart';
 import 'package:ui/src/widgets/style.dart';
 
 /// A dialog shown after opening one or more openable items.
@@ -36,17 +37,13 @@ class OpenResultDialog extends StatelessWidget {
             const SizedBox(height: 16),
             const Text('Received:'),
             const SizedBox(height: 8),
-            ...result.drops.entries.map((entry) {
-              final itemName = entry.key;
-              final count = entry.value;
-              return Padding(
-                padding: const EdgeInsets.only(left: 16, bottom: 4),
-                child: Text(
-                  '${approximateCountString(count)} $itemName',
-                  style: const TextStyle(color: Style.successColor),
-                ),
-              );
-            }),
+            ...result.drops.entries.map(
+              (entry) => ItemCountRow(
+                item: entry.key,
+                count: entry.value,
+                countColor: Style.successColor,
+              ),
+            ),
             if (result.error != null) ...[
               const SizedBox(height: 16),
               Text(


### PR DESCRIPTION
## Summary
- Changed `OpenResult.drops` from `Map<String, int>` to `Map<Item, int>` so item objects are available in the UI for image display
- Added `ItemCountRow` widget for showing `count [icon] name` (without +/- sign prefix)
- Used `ItemCountRow` in `OpenResultDialog` so crate drops now show item images, matching other dialogs like welcome back

## Test plan
- [x] Logic tests pass (`dart test -r failures-only` from logic/)
- [ ] Open a crate in-game and verify the result dialog shows item images alongside counts and names