### PR TITLE
fix: use neutral background for equipment slots instead of green

### DIFF
--- a/ui/lib/src/widgets/equipment_slots.dart
+++ b/ui/lib/src/widgets/equipment_slots.dart
@@ -162,14 +162,8 @@ class _CompactSlotCell extends StatelessWidget {
         width: 40,
         height: 40,
         decoration: BoxDecoration(
-          color: item != null
-              ? Style.containerBackgroundFilled
-              : Style.containerBackgroundEmpty,
-          border: Border.all(
-            color: item != null
-                ? Style.cellBorderColorSuccess
-                : Style.iconColorDefault,
-          ),
+          color: Style.containerBackgroundEmpty,
+          border: Border.all(color: Style.cellBorderColor),
           borderRadius: BorderRadius.circular(4),
         ),
         child: item != null
@@ -293,15 +287,11 @@ class _GridSlotCell extends StatelessWidget {
           width: size,
           height: size,
           decoration: BoxDecoration(
-            color: item != null
-                ? Style.containerBackgroundFilled
-                : Style.containerBackgroundEmpty,
+            color: Style.containerBackgroundEmpty,
             border: Border.all(
               color: isLocked
                   ? Style.textColorSecondary
-                  : item != null
-                  ? Style.cellBorderColorSuccess
-                  : Style.iconColorDefault,
+                  : Style.cellBorderColor,
             ),
             borderRadius: BorderRadius.circular(4),
           ),


### PR DESCRIPTION
## Summary
- Remove green background and green border from equipped equipment slots
- Use consistent dark grey background (`grey.shade800`) and grey border (`grey.shade600`) for all slots, matching real Melvor Idle styling
- Equipped items now simply show the item image over the neutral background, preventing green items from blending in

## Test plan
- [x] All 164 UI tests pass
- [ ] Visually verify equipment grid dialog shows items on dark grey background
- [ ] Verify compact equipment slots in combat UI also use neutral styling
- [ ] Check that green items (e.g. herbs, gems) are clearly visible when equipped