### PR TITLE
feat: staggered slide-in animation for chest open results

### DIFF
--- a/ui/lib/src/widgets/open_result_dialog.dart
+++ b/ui/lib/src/widgets/open_result_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:logic/logic.dart';
 import 'package:ui/src/widgets/item_count_row.dart';
@@ -5,7 +7,8 @@ import 'package:ui/src/widgets/style.dart';
 
 /// A dialog shown after opening one or more openable items.
 /// Displays how many were opened and the combined drops received.
-class OpenResultDialog extends StatelessWidget {
+/// Each drop row slides in from the left with a staggered delay.
+class OpenResultDialog extends StatefulWidget {
   const OpenResultDialog({
     required this.itemName,
     required this.result,
@@ -15,14 +18,63 @@ class OpenResultDialog extends StatelessWidget {
   final String itemName;
   final OpenResult result;
 
+  @override
+  State<OpenResultDialog> createState() => _OpenResultDialogState();
+}
+
+class _OpenResultDialogState extends State<OpenResultDialog>
+    with TickerProviderStateMixin {
+  static const _staggerDelay = Duration(milliseconds: 200);
+  static const _slideDuration = Duration(milliseconds: 300);
+
+  late final List<AnimationController> _controllers;
+  late final List<Animation<Offset>> _slideAnimations;
+  late final List<Animation<double>> _fadeAnimations;
+
+  @override
+  void initState() {
+    super.initState();
+    final dropCount = widget.result.drops.length;
+    _controllers = List.generate(dropCount, (i) {
+      return AnimationController(vsync: this, duration: _slideDuration);
+    });
+    _slideAnimations = _controllers.map((c) {
+      return Tween<Offset>(
+        begin: const Offset(-1, 0),
+        end: Offset.zero,
+      ).animate(CurvedAnimation(parent: c, curve: Curves.easeOut));
+    }).toList();
+    _fadeAnimations = _controllers.map((c) {
+      return CurvedAnimation(parent: c, curve: Curves.easeOut);
+    }).toList();
+
+    unawaited(_startAnimations());
+  }
+
+  Future<void> _startAnimations() async {
+    for (final controller in _controllers) {
+      unawaited(controller.forward());
+      await Future<void>.delayed(_staggerDelay);
+    }
+  }
+
+  @override
+  void dispose() {
+    for (final controller in _controllers) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
   String get _openedText {
-    final count = result.openedCount;
+    final count = widget.result.openedCount;
     final plural = count > 1 ? 's' : '';
-    return 'Opened $count $itemName$plural';
+    return 'Opened $count ${widget.itemName}$plural';
   }
 
   @override
   Widget build(BuildContext context) {
+    final dropEntries = widget.result.drops.entries.toList();
     return AlertDialog(
       title: const Text('Items Opened'),
       content: SingleChildScrollView(
@@ -37,17 +89,22 @@ class OpenResultDialog extends StatelessWidget {
             const SizedBox(height: 16),
             const Text('Received:'),
             const SizedBox(height: 8),
-            ...result.drops.entries.map(
-              (entry) => ItemCountRow(
-                item: entry.key,
-                count: entry.value,
-                countColor: Style.successColor,
+            for (var i = 0; i < dropEntries.length; i++)
+              SlideTransition(
+                position: _slideAnimations[i],
+                child: FadeTransition(
+                  opacity: _fadeAnimations[i],
+                  child: ItemCountRow(
+                    item: dropEntries[i].key,
+                    count: dropEntries[i].value,
+                    countColor: Style.successColor,
+                  ),
+                ),
               ),
-            ),
-            if (result.error != null) ...[
+            if (widget.result.error != null) ...[
               const SizedBox(height: 16),
               Text(
-                result.error!,
+                widget.result.error!,
                 style: TextStyle(
                   color: Style.shopPurchasedColor,
                   fontStyle: FontStyle.italic,


### PR DESCRIPTION
## Summary
- Each drop row in the chest open result dialog now slides in from the left with a fade animation
- Rows are staggered 200ms apart with a 300ms slide duration, making chest opening feel more dramatic
- Converted `OpenResultDialog` from `StatelessWidget` to `StatefulWidget` with `TickerProviderStateMixin` to manage animation controllers

## Test plan
- [x] Existing UI tests pass
- [ ] Open an egg chest (or other openable) and verify rows animate in one by one
- [ ] Open a chest with many drop types to verify stagger timing feels good
- [ ] Dismiss dialog before all animations complete to verify no errors