### PR TITLE
fix: center equipment grid in dialog

### DIFF
--- a/ui/lib/src/widgets/equipment_slots.dart
+++ b/ui/lib/src/widgets/equipment_slots.dart
@@ -194,7 +194,7 @@ class EquipmentGridDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: const Text('Equipment'),
-      content: const EquipmentGrid(),
+      content: const Center(widthFactor: 1, child: EquipmentGrid()),
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),


### PR DESCRIPTION
## Summary
- Center the equipment grid within the equipment dialog (was right-aligned)

## Test plan
- [ ] Open equipment dialog and verify the grid is centered, not right-aligned