### PR TITLE
feat: add food selector to thieving page

### DIFF
--- a/ui/lib/src/screens/combat.dart
+++ b/ui/lib/src/screens/combat.dart
@@ -3,6 +3,7 @@ import 'package:logic/logic.dart';
 import 'package:ui/src/logic/redux_actions.dart';
 import 'package:ui/src/widgets/attack_style_selector.dart';
 import 'package:ui/src/widgets/cached_image.dart';
+import 'package:ui/src/widgets/compact_food_selector.dart';
 import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/currency_display.dart';
 import 'package:ui/src/widgets/game_scaffold.dart';
@@ -712,151 +713,10 @@ class _PlayerStatsCard extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             // Compact food selector
-            _CompactFoodSelector(equipment: equipment, canEat: canEat),
+            CompactFoodSelector(equipment: equipment, canEat: canEat),
           ],
         ),
       ),
-    );
-  }
-}
-
-class _CompactFoodSelector extends StatelessWidget {
-  const _CompactFoodSelector({required this.equipment, required this.canEat});
-
-  final Equipment equipment;
-  final bool canEat;
-
-  @override
-  Widget build(BuildContext context) {
-    final selectedSlot = equipment.selectedFoodSlot;
-    final selectedFood = equipment.selectedFood;
-
-    // Find previous/next slots with food for navigation
-    int? findPrevSlot() {
-      for (var i = selectedSlot - 1; i >= 0; i--) {
-        if (equipment.foodSlots[i] != null) return i;
-      }
-      // Wrap around
-      for (var i = foodSlotCount - 1; i > selectedSlot; i--) {
-        if (equipment.foodSlots[i] != null) return i;
-      }
-      return null;
-    }
-
-    int? findNextSlot() {
-      for (var i = selectedSlot + 1; i < foodSlotCount; i++) {
-        if (equipment.foodSlots[i] != null) return i;
-      }
-      // Wrap around
-      for (var i = 0; i < selectedSlot; i++) {
-        if (equipment.foodSlots[i] != null) return i;
-      }
-      return null;
-    }
-
-    final prevSlot = findPrevSlot();
-    final nextSlot = findNextSlot();
-    final hasMultipleFood = prevSlot != null && prevSlot != selectedSlot;
-
-    return Row(
-      children: [
-        // Left arrow
-        IconButton(
-          icon: const Icon(Icons.chevron_left, size: 20),
-          onPressed: hasMultipleFood
-              ? () =>
-                    context.dispatch(SelectFoodSlotAction(slotIndex: prevSlot))
-              : null,
-          visualDensity: VisualDensity.compact,
-          padding: EdgeInsets.zero,
-          constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
-        ),
-        // Food display
-        Expanded(
-          child: Container(
-            height: 36,
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            decoration: BoxDecoration(
-              color: selectedFood != null
-                  ? Style.containerBackgroundFilled
-                  : Style.containerBackgroundEmpty,
-              borderRadius: BorderRadius.circular(4),
-              border: Border.all(color: Style.iconColorDefault),
-            ),
-            child: selectedFood != null
-                ? Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      ItemImage(item: selectedFood.item, size: 24),
-                      const SizedBox(width: 6),
-                      Flexible(
-                        child: Text(
-                          selectedFood.item.name,
-                          style: const TextStyle(fontSize: 13),
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                      const SizedBox(width: 4),
-                      Text(
-                        'x${approximateCountString(selectedFood.count)}',
-                        style: const TextStyle(
-                          fontSize: 12,
-                          fontWeight: FontWeight.bold,
-                          color: Style.textColorSecondary,
-                        ),
-                      ),
-                      const SizedBox(width: 4),
-                      GestureDetector(
-                        onTap: () => context.dispatch(
-                          UnequipFoodAction(slotIndex: selectedSlot),
-                        ),
-                        child: const Icon(
-                          Icons.close,
-                          size: 16,
-                          color: Style.textColorSecondary,
-                        ),
-                      ),
-                    ],
-                  )
-                : const Center(
-                    child: Text(
-                      'No food equipped',
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: Style.textColorSecondary,
-                      ),
-                    ),
-                  ),
-          ),
-        ),
-        // Right arrow
-        IconButton(
-          icon: const Icon(Icons.chevron_right, size: 20),
-          onPressed: hasMultipleFood
-              ? () =>
-                    context.dispatch(SelectFoodSlotAction(slotIndex: nextSlot!))
-              : null,
-          visualDensity: VisualDensity.compact,
-          padding: EdgeInsets.zero,
-          constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
-        ),
-        const SizedBox(width: 4),
-        // Eat button
-        SizedBox(
-          height: 36,
-          child: ElevatedButton(
-            onPressed: canEat ? () => context.dispatch(EatFoodAction()) : null,
-            style: ElevatedButton.styleFrom(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-            ),
-            child: Text(
-              selectedFood != null
-                  ? 'Eat +${selectedFood.item.healsFor}'
-                  : 'Eat',
-            ),
-          ),
-        ),
-      ],
     );
   }
 }

--- a/ui/lib/src/screens/thieving.dart
+++ b/ui/lib/src/screens/thieving.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart' hide Action;
 import 'package:logic/logic.dart';
 import 'package:ui/src/logic/redux_actions.dart';
 import 'package:ui/src/widgets/cached_image.dart';
+import 'package:ui/src/widgets/compact_food_selector.dart';
 import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/game_scaffold.dart';
 import 'package:ui/src/widgets/hp_bar.dart';
@@ -66,15 +67,26 @@ class _ThievingPageState extends State<ThievingPage> {
           const MasteryPoolProgress(skill: skill),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: PlayerHpDisplay(
-              currentHp: playerHp,
-              maxHp: maxPlayerHp,
-              showAutoEat: state.hasAutoEat,
-              autoEatThresholdPercent: state
-                  .createCombatModifierProvider(
-                    conditionContext: ConditionContext.empty,
-                  )
-                  .autoEatThreshold,
+            child: Column(
+              children: [
+                PlayerHpDisplay(
+                  currentHp: playerHp,
+                  maxHp: maxPlayerHp,
+                  showAutoEat: state.hasAutoEat,
+                  autoEatThresholdPercent: state
+                      .createCombatModifierProvider(
+                        conditionContext: ConditionContext.empty,
+                      )
+                      .autoEatThreshold,
+                ),
+                const SizedBox(height: 8),
+                CompactFoodSelector(
+                  equipment: state.equipment,
+                  canEat:
+                      state.equipment.selectedFood != null &&
+                      playerHp < maxPlayerHp,
+                ),
+              ],
             ),
           ),
           Expanded(

--- a/ui/lib/src/widgets/compact_food_selector.dart
+++ b/ui/lib/src/widgets/compact_food_selector.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:logic/logic.dart';
+import 'package:ui/src/logic/redux_actions.dart';
+import 'package:ui/src/widgets/item_image.dart';
+import 'package:ui/src/widgets/style.dart';
+
+class CompactFoodSelector extends StatelessWidget {
+  const CompactFoodSelector({
+    required this.equipment,
+    required this.canEat,
+    super.key,
+  });
+
+  final Equipment equipment;
+  final bool canEat;
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedSlot = equipment.selectedFoodSlot;
+    final selectedFood = equipment.selectedFood;
+
+    // Find previous/next slots with food for navigation
+    int? findPrevSlot() {
+      for (var i = selectedSlot - 1; i >= 0; i--) {
+        if (equipment.foodSlots[i] != null) return i;
+      }
+      // Wrap around
+      for (var i = foodSlotCount - 1; i > selectedSlot; i--) {
+        if (equipment.foodSlots[i] != null) return i;
+      }
+      return null;
+    }
+
+    int? findNextSlot() {
+      for (var i = selectedSlot + 1; i < foodSlotCount; i++) {
+        if (equipment.foodSlots[i] != null) return i;
+      }
+      // Wrap around
+      for (var i = 0; i < selectedSlot; i++) {
+        if (equipment.foodSlots[i] != null) return i;
+      }
+      return null;
+    }
+
+    final prevSlot = findPrevSlot();
+    final nextSlot = findNextSlot();
+    final hasMultipleFood = prevSlot != null && prevSlot != selectedSlot;
+
+    return Row(
+      children: [
+        // Left arrow
+        IconButton(
+          icon: const Icon(Icons.chevron_left, size: 20),
+          onPressed: hasMultipleFood
+              ? () =>
+                    context.dispatch(SelectFoodSlotAction(slotIndex: prevSlot))
+              : null,
+          visualDensity: VisualDensity.compact,
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+        ),
+        // Food display
+        Expanded(
+          child: Container(
+            height: 36,
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            decoration: BoxDecoration(
+              color: selectedFood != null
+                  ? Style.containerBackgroundFilled
+                  : Style.containerBackgroundEmpty,
+              borderRadius: BorderRadius.circular(4),
+              border: Border.all(color: Style.iconColorDefault),
+            ),
+            child: selectedFood != null
+                ? Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      ItemImage(item: selectedFood.item, size: 24),
+                      const SizedBox(width: 6),
+                      Flexible(
+                        child: Text(
+                          selectedFood.item.name,
+                          style: const TextStyle(fontSize: 13),
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        'x${approximateCountString(selectedFood.count)}',
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold,
+                          color: Style.textColorSecondary,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      GestureDetector(
+                        onTap: () => context.dispatch(
+                          UnequipFoodAction(slotIndex: selectedSlot),
+                        ),
+                        child: const Icon(
+                          Icons.close,
+                          size: 16,
+                          color: Style.textColorSecondary,
+                        ),
+                      ),
+                    ],
+                  )
+                : const Center(
+                    child: Text(
+                      'No food equipped',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Style.textColorSecondary,
+                      ),
+                    ),
+                  ),
+          ),
+        ),
+        // Right arrow
+        IconButton(
+          icon: const Icon(Icons.chevron_right, size: 20),
+          onPressed: hasMultipleFood
+              ? () =>
+                    context.dispatch(SelectFoodSlotAction(slotIndex: nextSlot!))
+              : null,
+          visualDensity: VisualDensity.compact,
+          padding: EdgeInsets.zero,
+          constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+        ),
+        const SizedBox(width: 4),
+        // Eat button
+        SizedBox(
+          height: 36,
+          child: ElevatedButton(
+            onPressed: canEat ? () => context.dispatch(EatFoodAction()) : null,
+            style: ElevatedButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+            ),
+            child: Text(
+              selectedFood != null
+                  ? 'Eat +${selectedFood.item.healsFor}'
+                  : 'Eat',
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Extract `_CompactFoodSelector` from `combat.dart` into a shared `CompactFoodSelector` widget
- Add the food selector to the thieving page below the HP display, so players can view, switch, and eat food while thieving

## Test plan
- [x] `flutter analyze` passes with no issues
- [x] All 175 UI tests pass
- [ ] Verify food selector appears on thieving page and functions correctly (eat, switch slots, unequip)
- [ ] Verify combat page food selector still works as before