### PR TITLE
fix: constrain dialog max width on desktop

### DIFF
--- a/ui/lib/main.dart
+++ b/ui/lib/main.dart
@@ -474,7 +474,11 @@ class _MyAppState extends State<MyApp> {
     if (!_isDataLoaded) {
       return MaterialApp(
         themeMode: ThemeMode.dark,
-        darkTheme: ThemeData.dark(),
+        darkTheme: ThemeData.dark().copyWith(
+          dialogTheme: const DialogThemeData(
+            constraints: BoxConstraints(maxWidth: 560),
+          ),
+        ),
         home: const Scaffold(body: Center(child: CircularProgressIndicator())),
       );
     }
@@ -607,7 +611,11 @@ class _GameAppState extends State<_GameApp> {
           child: MaterialApp.router(
             routerConfig: router,
             themeMode: ThemeMode.dark,
-            darkTheme: ThemeData.dark(),
+            darkTheme: ThemeData.dark().copyWith(
+              dialogTheme: const DialogThemeData(
+                constraints: BoxConstraints(maxWidth: 560),
+              ),
+            ),
             builder: (context, child) {
               return ToastOverlay(
                 service: toastService,

--- a/ui/lib/src/widgets/spend_mastery_dialog.dart
+++ b/ui/lib/src/widgets/spend_mastery_dialog.dart
@@ -38,7 +38,6 @@ class _SpendMasteryDialogState extends State<SpendMasteryDialog> {
         final claimableTokens = state.claimableMasteryTokenCount(widget.skill);
 
         return AlertDialog(
-          constraints: const BoxConstraints(maxWidth: 600),
           title: const Text('Spend Mastery XP'),
           content: SizedBox(
             width: double.maxFinite,


### PR DESCRIPTION
## Summary
- Adds `DialogThemeData(constraints: BoxConstraints(maxWidth: 560))` to both theme definitions in `main.dart`, capping all dialogs at 560px on wide screens.
- Removes redundant per-dialog `maxWidth: 600` constraint from `SpendMasteryDialog` (now covered by theme).

## Test plan
- [x] All 164 UI tests pass
- [ ] Verify dialogs (purchase, sale, mastery, etc.) look reasonable on desktop-width windows