### PR TITLE
fix: match Melvor Idle image sizes

### DIFF
--- a/ui/lib/src/screens/bank.dart
+++ b/ui/lib/src/screens/bank.dart
@@ -413,7 +413,12 @@ class StackCell extends StatelessWidget {
                   : Style.cellBorderColorSuccess,
               count: stack.count,
               child: Center(
-                child: ItemImage(item: stack.item, size: _inradius * 0.6),
+                child: ItemImage(
+                  item: stack.item,
+                  size: MediaQuery.sizeOf(context).width >= sidebarBreakpoint
+                      ? Style.bankImageSizeDesktop
+                      : Style.bankImageSizeMobile,
+                ),
               ),
             ),
             // Selection checkmark overlay

--- a/ui/lib/src/screens/cooking.dart
+++ b/ui/lib/src/screens/cooking.dart
@@ -921,7 +921,10 @@ class _RecipeCard extends StatelessWidget {
                   // Product image with mastery below
                   Column(
                     children: [
-                      ItemImage(item: productItem, size: 64),
+                      ItemImage(
+                        item: productItem,
+                        size: Style.featuredImageSize,
+                      ),
                       const SizedBox(height: 8),
                       // Mastery level with trophy
                       Row(

--- a/ui/lib/src/screens/firemaking.dart
+++ b/ui/lib/src/screens/firemaking.dart
@@ -554,7 +554,7 @@ class _LogCard extends StatelessWidget {
                   // Log image with mastery below
                   Column(
                     children: [
-                      ItemImage(item: logItem, size: 64),
+                      ItemImage(item: logItem, size: Style.featuredImageSize),
                       const SizedBox(height: 8),
                       // Mastery level with trophy
                       Row(
@@ -720,7 +720,10 @@ class _BonfireCard extends StatelessWidget {
           // Header row with bonfire image
           Row(
             children: [
-              CachedImage(assetPath: bonfireImage, size: 64),
+              CachedImage(
+                assetPath: bonfireImage,
+                size: Style.featuredImageSize,
+              ),
               const SizedBox(width: 16),
               Expanded(
                 child: Column(

--- a/ui/lib/src/screens/thieving.dart
+++ b/ui/lib/src/screens/thieving.dart
@@ -195,7 +195,12 @@ class _SelectedActionDisplay extends StatelessWidget {
           ],
           // Header: NPC Image + Pickpocket + NPC Name
           if (action.media != null) ...[
-            Center(child: CachedImage(assetPath: action.media, size: 64)),
+            Center(
+              child: CachedImage(
+                assetPath: action.media,
+                size: Style.featuredImageSize,
+              ),
+            ),
             const SizedBox(height: 8),
           ],
           const Text(

--- a/ui/lib/src/widgets/action_grid.dart
+++ b/ui/lib/src/widgets/action_grid.dart
@@ -99,7 +99,7 @@ class LockedActionCell extends StatelessWidget {
         children: [
           const Text('Locked'),
           const SizedBox(height: 8),
-          CachedImage(assetPath: imageAsset, size: 64),
+          CachedImage(assetPath: imageAsset, size: Style.featuredImageSize),
           const SizedBox(height: 8),
           LockedLevelBadge(level: unlockLevel),
         ],
@@ -265,7 +265,7 @@ class WoodcuttingActionCell extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 4),
-          CachedImage(assetPath: action.media, size: 64),
+          CachedImage(assetPath: action.media, size: Style.featuredImageSize),
           const Spacer(),
           ActionProgressBar(action: action),
           const SizedBox(height: 8),
@@ -349,7 +349,7 @@ class MiningActionCell extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 4),
-          CachedImage(assetPath: action.media, size: 64),
+          CachedImage(assetPath: action.media, size: Style.featuredImageSize),
           const SizedBox(height: 4),
           if (respawnTimeRemaining case final respawnTime?) ...[
             Text(

--- a/ui/lib/src/widgets/style.dart
+++ b/ui/lib/src/widgets/style.dart
@@ -129,4 +129,9 @@ class Style {
 
   // Currency/stat value text color (used in nav drawer for GP, SC, HP, Prayer)
   static const Color currencyValueColor = Colors.green;
+
+  // Image sizes (matching Melvor Idle)
+  static const double featuredImageSize = 74;
+  static const double bankImageSizeMobile = 28;
+  static const double bankImageSizeDesktop = 32;
 }


### PR DESCRIPTION
## Summary
- Add `Style.featuredImageSize` (74px) and `Style.bankImageSizeMobile` (28px) / `Style.bankImageSizeDesktop` (32px) constants matching original Melvor Idle
- Update featured item images (action grid, cooking, firemaking, thieving) from 64 to 74
- Update bank grid item images to use responsive 28/32 sizing based on screen width

## Test plan
- [ ] Verify featured images (woodcutting, mining, cooking, firemaking, thieving) render at 74x74
- [ ] Verify bank grid items render at 28x28 on mobile and 32x32 on desktop