### PR TITLE
feat: apply mastery-level modifiers to skill actions

### DIFF
--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -540,6 +540,18 @@ bool rollAndCollectDrops(
 
   final doublingChance = action.doublingChance(modifiers);
 
+  // Compute flat bonus to primary product quantity from mastery/modifiers.
+  final flatProductBonus = modifiers
+      .flatBasePrimaryProductQuantity(
+        skillId: action.skill.id,
+        actionId: action.id.localId,
+        categoryId: action.categoryId,
+      )
+      .floor();
+
+  // The primary product IDs are the keys in the action's output map.
+  final primaryProductIds = action.outputs.keys.toSet();
+
   for (final drop in registries.drops.allDropsForAction(action, selection)) {
     ItemStack? itemStack;
 
@@ -561,6 +573,13 @@ bool rollAndCollectDrops(
       // Only roll if rate < 1.0 to preserve random sequence for other drops
       if (effectiveRate >= 1.0 || random.nextDouble() < effectiveRate) {
         itemStack = drop.toItemStack(registries.items);
+        // Apply flat primary product quantity bonus from mastery.
+        if (flatProductBonus > 0 && primaryProductIds.contains(drop.itemId)) {
+          itemStack = ItemStack(
+            itemStack.item,
+            count: itemStack.count + flatProductBonus,
+          );
+        }
       }
     } else if (drop is ThievingUniqueDrop) {
       // Compute actual player stealth for accurate NPC unique drop rate.
@@ -855,6 +874,26 @@ void _rollMarkDiscovery(
   }
 }
 
+/// Rolls the skill preservation chance to determine if inputs are preserved.
+/// Returns true if inputs should be preserved (not consumed).
+/// In Melvor, preservation chance is capped at 80% by default, modified by
+/// skillPreservationCap.
+bool _rollPreservation(
+  SkillAction action,
+  ModifierAccessors modifiers,
+  Random random,
+) {
+  final chance = modifiers.skillPreservationChance(
+    skillId: action.skill.id,
+    actionId: action.id.localId,
+    categoryId: action.categoryId,
+  );
+  if (chance <= 0) return false;
+  final cap = 80 + modifiers.skillPreservationCap(skillId: action.skill.id);
+  final effective = chance.clamp(0, cap).toDouble() / 100.0;
+  return random.nextDouble() < effective;
+}
+
 /// Completes a skill action, consuming inputs, adding outputs, and awarding XP.
 /// Returns true if the action can repeat (no items were dropped).
 bool completeAction(
@@ -866,19 +905,26 @@ bool completeAction(
   final actionState = builder.state.actionState(action.id);
   final selection = actionState.recipeSelection(action);
 
-  // Consume required items (using selected recipe if applicable)
-  final inputs = action.inputsForRecipe(selection);
-  for (final requirement in inputs.entries) {
-    final item = registries.items.byId(requirement.key);
-    builder.removeInventory(ItemStack(item, count: requirement.value));
-  }
-
-  // Roll drops with doubling applied (using recipe for output multiplier)
+  // Create modifier provider early so it can be used for input consumption.
   final modifierProvider = builder.state.createActionModifierProvider(
     action,
     conditionContext: ConditionContext.empty, // Skill action, no combat.
     consumesOnType: null,
   );
+
+  // Check skill preservation chance (chance to not consume inputs).
+  final preserved = _rollPreservation(action, modifierProvider, random);
+
+  if (!preserved) {
+    // Consume required items (using selected recipe if applicable)
+    final inputs = action.inputsForRecipe(selection);
+    for (final requirement in inputs.entries) {
+      final item = registries.items.byId(requirement.key);
+      builder.removeInventory(ItemStack(item, count: requirement.value));
+    }
+  }
+
+  // Roll drops with doubling applied (using recipe for output multiplier)
   final canRepeatAction = rollAndCollectDrops(
     builder,
     action,

--- a/logic/test/mastery_modifier_test.dart
+++ b/logic/test/mastery_modifier_test.dart
@@ -1,0 +1,162 @@
+import 'dart:math';
+
+import 'package:logic/logic.dart';
+import 'package:test/test.dart';
+
+import 'test_helper.dart';
+
+void main() {
+  late RunecraftingAction airRune;
+  late Item airRuneItem;
+  late Item runeEssence;
+  late SkillAction bronzeBar;
+  late Item copperOre;
+  late Item tinOre;
+
+  setUpAll(() async {
+    await loadTestRegistries();
+    airRune = testRegistries.runecraftingAction('Air Rune');
+    airRuneItem = testItems.byName('Air Rune');
+    runeEssence = testItems.byName('Rune Essence');
+
+    bronzeBar = testRegistries.smithingAction('Bronze Bar');
+    copperOre = testItems.byName('Copper Ore');
+    tinOre = testItems.byName('Tin Ore');
+  });
+
+  group('flatBasePrimaryProductQuantity', () {
+    GlobalState stateWithMastery(int masteryLevel) {
+      return GlobalState.test(
+        testRegistries,
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(runeEssence, count: 100),
+        ]),
+        actionStates: {
+          airRune.id: ActionState(masteryXp: startXpForLevel(masteryLevel)),
+        },
+        skillStates: {
+          Skill.runecrafting: SkillState(
+            xp: startXpForLevel(99),
+            masteryPoolXp: 0,
+          ),
+        },
+      );
+    }
+
+    test('produces 1 rune at mastery level 1 (no bonus)', () {
+      final state = stateWithMastery(1);
+      final random = Random(42);
+
+      final builder = StateUpdateBuilder(state);
+      completeAction(builder, airRune, random: random);
+      final newState = builder.build();
+
+      expect(newState.inventory.countOfItem(airRuneItem), 1);
+    });
+
+    test('produces extra runes at mastery level 15', () {
+      final state = stateWithMastery(15);
+      final random = Random(42);
+
+      final builder = StateUpdateBuilder(state);
+      completeAction(builder, airRune, random: random);
+      final newState = builder.build();
+
+      // At mastery 15, the first flatBasePrimaryProductQuantity bonus
+      // activates (+1), so we should get 2 runes.
+      expect(newState.inventory.countOfItem(airRuneItem), 2);
+    });
+
+    test('produces more runes at higher mastery levels', () {
+      // At mastery 90, the scaling bonus has triggered 6 times
+      // (levels 15, 30, 45, 60, 75, 90) giving +6.
+      final state = stateWithMastery(90);
+      final random = Random(42);
+
+      final builder = StateUpdateBuilder(state);
+      completeAction(builder, airRune, random: random);
+      final newState = builder.build();
+
+      expect(newState.inventory.countOfItem(airRuneItem), 7);
+    });
+
+    test('produces max runes at mastery level 99', () {
+      // At mastery 99: scaling gives +6 (at 15,30,45,60,75,90)
+      // plus the level 99 bonus of +4 = +10 total, so 11 runes.
+      final state = stateWithMastery(99);
+      final random = Random(42);
+
+      final builder = StateUpdateBuilder(state);
+      completeAction(builder, airRune, random: random);
+      final newState = builder.build();
+
+      expect(newState.inventory.countOfItem(airRuneItem), 11);
+    });
+  });
+
+  group('skillPreservationChance', () {
+    GlobalState stateWithMastery(int masteryLevel) {
+      return GlobalState.test(
+        testRegistries,
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(copperOre, count: 100),
+          ItemStack(tinOre, count: 100),
+        ]),
+        actionStates: {
+          bronzeBar.id: ActionState(masteryXp: startXpForLevel(masteryLevel)),
+        },
+        skillStates: {
+          Skill.smithing: SkillState(xp: startXpForLevel(99), masteryPoolXp: 0),
+        },
+      );
+    }
+
+    test('consumes inputs at mastery level 1 (no preservation)', () {
+      final state = stateWithMastery(1);
+      final random = Random(42);
+
+      final builder = StateUpdateBuilder(state);
+      completeAction(builder, bronzeBar, random: random);
+      final newState = builder.build();
+
+      // Inputs should be consumed normally.
+      expect(newState.inventory.countOfItem(copperOre), 99);
+      expect(newState.inventory.countOfItem(tinOre), 99);
+    });
+
+    test('sometimes preserves inputs at high mastery', () {
+      // At high mastery, preservation chance is non-zero.
+      // Run many completions and verify some inputs are preserved.
+      final state = stateWithMastery(99);
+      final random = Random(42);
+
+      var currentState = state;
+      for (var i = 0; i < 100; i++) {
+        currentState = currentState.startAction(bronzeBar, random: random);
+        final builder = StateUpdateBuilder(currentState);
+        completeAction(builder, bronzeBar, random: random);
+        currentState = builder.build();
+      }
+
+      // We did 100 completions. Without preservation, we'd use 100 of each.
+      final copperUsed = 100 - currentState.inventory.countOfItem(copperOre);
+      final tinUsed = 100 - currentState.inventory.countOfItem(tinOre);
+
+      // With any preservation chance, some should be saved.
+      // The exact number depends on the mastery bonus data.
+      expect(
+        copperUsed,
+        lessThan(100),
+        reason: 'some copper should be preserved at mastery 99',
+      );
+      expect(
+        tinUsed,
+        lessThan(100),
+        reason: 'some tin should be preserved at mastery 99',
+      );
+      // But we should have still consumed some.
+      expect(copperUsed, greaterThan(0));
+      expect(tinUsed, greaterThan(0));
+    });
+  });
+}

--- a/logic/test/test_helper.dart
+++ b/logic/test/test_helper.dart
@@ -98,6 +98,15 @@ extension RegistriesTestHelpers on Registries {
 
   AgilityObstacle agilityObstacle(String name) =>
       _bySkillAndName(Skill.agility, name) as AgilityObstacle;
+
+  RunecraftingAction runecraftingAction(String name) =>
+      _bySkillAndName(Skill.runecrafting, name) as RunecraftingAction;
+
+  SkillAction craftingAction(String name) =>
+      _bySkillAndName(Skill.crafting, name) as SkillAction;
+
+  SkillAction fletchingAction(String name) =>
+      _bySkillAndName(Skill.fletching, name) as SkillAction;
 }
 
 /// Extension providing a short helper for the common test pattern of


### PR DESCRIPTION
## Summary
- Implements **skillPreservationChance** mastery modifier: chance to not consume inputs on action completion (applies to smithing, crafting, fletching, herblore via mastery bonuses)
- Implements **flatBasePrimaryProductQuantity** mastery modifier: increases base output quantity for primary products (applies to runecrafting runes, farming, summoning via mastery bonuses)
- Moves `ModifierProvider` creation before input consumption in `completeAction` so preservation can be evaluated before inputs are removed

These modifiers were already defined in `modifier_names.dart` and loaded through `MasteryBonusRegistry`/`ModifierProvider`, but no game logic was reading them.

## Test plan
- [x] New `mastery_modifier_test.dart` with 6 tests covering:
  - `flatBasePrimaryProductQuantity`: verifies rune output scales with mastery (1 → 2 → 7 → 11 runes at levels 1/15/90/99)
  - `skillPreservationChance`: verifies inputs are consumed at mastery 1, and statistically preserved at mastery 99 over 100 completions
- [x] All 2316 existing tests pass
- [x] `dart analyze --fatal-infos` clean
- [x] `cspell` clean