### PR TITLE
feat: add fishing modifier support

### DIFF
--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -617,12 +617,42 @@ bool rollAndCollectDrops(
         totalMastery: totalMastery,
         hasRequiredItem: hasRequiredItem,
       );
+    } else if (drop is FishingJunkDrop) {
+      // cannotFishJunk modifier suppresses junk drops entirely.
+      final cannotJunk = modifiers.cannotFishJunk(actionId: action.id.localId);
+      if (cannotJunk <= 0) {
+        itemStack = drop.roll(registries.items, random);
+      }
+    } else if (drop is FishingSpecialDrop) {
+      // Apply fishing special chance modifiers to the base rate.
+      final specialBonus =
+          modifiers.fishingSpecialChance +
+          modifiers.fishingAdditionalSpecialItemChance +
+          modifiers.bonusFishingSpecialChance(actionId: action.id.localId);
+      final effectiveRate = (drop.rate + specialBonus / 100.0).clamp(0.0, 1.0);
+      if (random.nextDouble() < effectiveRate) {
+        itemStack = drop.child.roll(registries.items, random);
+      }
     } else {
       // For other Droppable types (DropTable, DropChance), use base roll
       itemStack = drop.roll(registries.items, random);
     }
 
     if (itemStack != null) {
+      // fishingCookedChance: chance to receive cooked fish instead of raw.
+      // Only applies to the primary fishing product (the raw fish).
+      if (action is FishingAction &&
+          primaryProductIds.contains(itemStack.item.id)) {
+        final cookedChance = modifiers.fishingCookedChance;
+        if (cookedChance > 0 && random.nextDouble() < cookedChance / 100.0) {
+          final cookedId = registries.cooking.cookedForRaw(itemStack.item.id);
+          if (cookedId != null) {
+            final cookedItem = registries.items.byId(cookedId);
+            itemStack = ItemStack(cookedItem, count: itemStack.count);
+          }
+        }
+      }
+
       // Apply doubling chance
       if (doublingChance > 0 && random.nextDouble() < doublingChance) {
         itemStack = ItemStack(itemStack.item, count: itemStack.count * 2);

--- a/logic/lib/src/data/actions.dart
+++ b/logic/lib/src/data/actions.dart
@@ -412,9 +412,9 @@ class DropsRegistry {
     final area = action.area;
     return [
       if (fishingJunk != null && area.junkChance > 0)
-        DropChance(fishingJunk!, rate: area.junkChance),
+        FishingJunkDrop(fishingJunk!, rate: area.junkChance),
       if (fishingSpecial != null && area.specialChance > 0)
-        DropChance(fishingSpecial!, rate: area.specialChance),
+        FishingSpecialDrop(fishingSpecial!, rate: area.specialChance),
     ];
   }
 }

--- a/logic/lib/src/data/cooking.dart
+++ b/logic/lib/src/data/cooking.dart
@@ -184,12 +184,20 @@ class CookingRegistry {
        _categories = categories {
     _byId = {for (final a in _actions) a.id.localId: a};
     _categoryById = {for (final c in _categories) c.id: c};
+    // Build reverse lookup: raw ingredient -> cooked product.
+    _cookedForRaw = {};
+    for (final action in _actions) {
+      for (final inputId in action.inputs.keys) {
+        _cookedForRaw[inputId] = action.productId;
+      }
+    }
   }
 
   final List<CookingAction> _actions;
   final List<CookingCategory> _categories;
   late final Map<MelvorId, CookingAction> _byId;
   late final Map<MelvorId, CookingCategory> _categoryById;
+  late final Map<MelvorId, MelvorId> _cookedForRaw;
 
   /// All cooking actions.
   List<CookingAction> get actions => _actions;
@@ -202,4 +210,8 @@ class CookingRegistry {
 
   /// Returns a cooking category by ID, or null if not found.
   CookingCategory? categoryById(MelvorId id) => _categoryById[id];
+
+  /// Returns the cooked product ID for a raw ingredient, or null if no
+  /// cooking recipe uses this item as input.
+  MelvorId? cookedForRaw(MelvorId rawItemId) => _cookedForRaw[rawItemId];
 }

--- a/logic/lib/src/types/drop.dart
+++ b/logic/lib/src/types/drop.dart
@@ -133,6 +133,25 @@ class DropChance extends Droppable {
   }
 }
 
+/// A fishing junk drop, tagged for modifier handling.
+///
+/// Wraps a junk [DropTable] with the area's junk chance. The
+/// `cannotFishJunk` modifier can suppress this drop entirely.
+@immutable
+class FishingJunkDrop extends DropChance {
+  const FishingJunkDrop(super.child, {required super.rate});
+}
+
+/// A fishing special item drop, tagged for modifier handling.
+///
+/// Wraps a special [DropTable] with the area's special chance. Modifiers
+/// like `fishingSpecialChance`, `bonusFishingSpecialChance`, and
+/// `fishingAdditionalSpecialItemChance` increase the effective rate.
+@immutable
+class FishingSpecialDrop extends DropChance {
+  const FishingSpecialDrop(super.child, {required super.rate});
+}
+
 /// Calculates drop chance based on player progress.
 ///
 /// Different implementations handle fixed chances vs scaling with level/mastery.

--- a/logic/test/fishing_modifier_test.dart
+++ b/logic/test/fishing_modifier_test.dart
@@ -1,0 +1,364 @@
+import 'dart:math';
+
+import 'package:logic/logic.dart';
+import 'package:test/test.dart';
+
+import 'test_helper.dart';
+
+void main() {
+  late FishingAction actionWithJunkAndSpecial;
+  late FishingAction actionNoJunk;
+
+  setUpAll(() async {
+    await loadTestRegistries();
+
+    // Find a fishing action in an area with both junk and special chances.
+    actionWithJunkAndSpecial = testRegistries.fishing.actions.firstWhere(
+      (a) => a.area.junkChance > 0 && a.area.specialChance > 0,
+    );
+
+    // Find a fishing action in an area with no junk chance.
+    actionNoJunk = testRegistries.fishing.actions.firstWhere(
+      (a) => a.area.junkChance == 0,
+    );
+  });
+
+  group('cannotFishJunk modifier', () {
+    test('junk drops normally when cannotFishJunk is 0', () {
+      final state = GlobalState.test(testRegistries);
+      final builder = StateUpdateBuilder(state);
+      final modifiers = StubModifierProvider();
+
+      // Run many iterations to ensure junk has a chance to drop.
+      var junkDropped = false;
+      for (var i = 0; i < 200; i++) {
+        final random = Random(i);
+        rollAndCollectDrops(
+          builder,
+          actionWithJunkAndSpecial,
+          modifiers,
+          random,
+          const NoSelectedRecipe(),
+        );
+      }
+
+      // Check if any junk item was added to inventory.
+      // Junk items are from the fishing junk table.
+      final junkTable = testDrops.fishingJunk!;
+      for (final entry in junkTable.entries) {
+        if (builder.state.inventory.countById(entry.itemID) > 0) {
+          junkDropped = true;
+          break;
+        }
+      }
+      expect(junkDropped, isTrue, reason: 'Junk should drop without modifier');
+    });
+
+    test('junk is suppressed when cannotFishJunk is active', () {
+      final state = GlobalState.test(testRegistries);
+      final builder = StateUpdateBuilder(state);
+      // cannotFishJunk > 0 means junk is suppressed.
+      final modifiers = StubModifierProvider({'cannotFishJunk': 1});
+
+      for (var i = 0; i < 200; i++) {
+        final random = Random(i);
+        rollAndCollectDrops(
+          builder,
+          actionWithJunkAndSpecial,
+          modifiers,
+          random,
+          const NoSelectedRecipe(),
+        );
+      }
+
+      // No junk items should have been added.
+      final junkTable = testDrops.fishingJunk!;
+      for (final entry in junkTable.entries) {
+        expect(
+          builder.state.inventory.countById(entry.itemID),
+          equals(0),
+          reason:
+              'Junk item ${entry.itemID} should not drop with '
+              'cannotFishJunk active',
+        );
+      }
+    });
+  });
+
+  group('fishingSpecialChance modifier', () {
+    test('special items drop more often with fishingSpecialChance bonus', () {
+      // Run with and without modifier, compare special item counts.
+      var specialCountWithout = 0;
+      var specialCountWith = 0;
+      final specialTable = testDrops.fishingSpecial!;
+      final specialIds = specialTable.entries.map((e) => e.itemID).toSet();
+
+      for (var i = 0; i < 500; i++) {
+        // Without modifier
+        final state1 = GlobalState.test(testRegistries);
+        final builder1 = StateUpdateBuilder(state1);
+        final random1 = Random(i);
+        rollAndCollectDrops(
+          builder1,
+          actionWithJunkAndSpecial,
+          StubModifierProvider(),
+          random1,
+          const NoSelectedRecipe(),
+        );
+        for (final id in specialIds) {
+          specialCountWithout += builder1.state.inventory.countById(id);
+        }
+
+        // With 100% bonus to fishingSpecialChance
+        final state2 = GlobalState.test(testRegistries);
+        final builder2 = StateUpdateBuilder(state2);
+        final random2 = Random(i);
+        rollAndCollectDrops(
+          builder2,
+          actionWithJunkAndSpecial,
+          StubModifierProvider({'fishingSpecialChance': 100}),
+          random2,
+          const NoSelectedRecipe(),
+        );
+        for (final id in specialIds) {
+          specialCountWith += builder2.state.inventory.countById(id);
+        }
+      }
+
+      expect(
+        specialCountWith,
+        greaterThan(specialCountWithout),
+        reason: 'fishingSpecialChance should increase special drops',
+      );
+    });
+  });
+
+  group('bonusFishingSpecialChance modifier', () {
+    test('increases special item drop rate', () {
+      var specialCountWithout = 0;
+      var specialCountWith = 0;
+      final specialTable = testDrops.fishingSpecial!;
+      final specialIds = specialTable.entries.map((e) => e.itemID).toSet();
+
+      for (var i = 0; i < 500; i++) {
+        // Without modifier
+        final state1 = GlobalState.test(testRegistries);
+        final builder1 = StateUpdateBuilder(state1);
+        final random1 = Random(i);
+        rollAndCollectDrops(
+          builder1,
+          actionWithJunkAndSpecial,
+          StubModifierProvider(),
+          random1,
+          const NoSelectedRecipe(),
+        );
+        for (final id in specialIds) {
+          specialCountWithout += builder1.state.inventory.countById(id);
+        }
+
+        // With bonus (action-scoped)
+        final state2 = GlobalState.test(testRegistries);
+        final builder2 = StateUpdateBuilder(state2);
+        final random2 = Random(i);
+        rollAndCollectDrops(
+          builder2,
+          actionWithJunkAndSpecial,
+          StubModifierProvider({'bonusFishingSpecialChance': 100}),
+          random2,
+          const NoSelectedRecipe(),
+        );
+        for (final id in specialIds) {
+          specialCountWith += builder2.state.inventory.countById(id);
+        }
+      }
+
+      expect(
+        specialCountWith,
+        greaterThan(specialCountWithout),
+        reason: 'bonusFishingSpecialChance should increase special drops',
+      );
+    });
+  });
+
+  group('fishingAdditionalSpecialItemChance modifier', () {
+    test('increases special item drop rate', () {
+      var specialCountWithout = 0;
+      var specialCountWith = 0;
+      final specialTable = testDrops.fishingSpecial!;
+      final specialIds = specialTable.entries.map((e) => e.itemID).toSet();
+
+      for (var i = 0; i < 500; i++) {
+        // Without modifier
+        final state1 = GlobalState.test(testRegistries);
+        final builder1 = StateUpdateBuilder(state1);
+        final random1 = Random(i);
+        rollAndCollectDrops(
+          builder1,
+          actionWithJunkAndSpecial,
+          StubModifierProvider(),
+          random1,
+          const NoSelectedRecipe(),
+        );
+        for (final id in specialIds) {
+          specialCountWithout += builder1.state.inventory.countById(id);
+        }
+
+        // With modifier
+        final state2 = GlobalState.test(testRegistries);
+        final builder2 = StateUpdateBuilder(state2);
+        final random2 = Random(i);
+        rollAndCollectDrops(
+          builder2,
+          actionWithJunkAndSpecial,
+          StubModifierProvider({'fishingAdditionalSpecialItemChance': 100}),
+          random2,
+          const NoSelectedRecipe(),
+        );
+        for (final id in specialIds) {
+          specialCountWith += builder2.state.inventory.countById(id);
+        }
+      }
+
+      expect(
+        specialCountWith,
+        greaterThan(specialCountWithout),
+        reason:
+            'fishingAdditionalSpecialItemChance should increase special drops',
+      );
+    });
+  });
+
+  group('fishingCookedChance modifier', () {
+    test('raw fish is replaced with cooked fish when modifier triggers', () {
+      final rawFishId = actionWithJunkAndSpecial.productId;
+      final cookedId = testRegistries.cooking.cookedForRaw(rawFishId);
+
+      // Skip if no cooking recipe exists for this fish.
+      if (cookedId == null) {
+        // Try another action that has a cooking counterpart.
+        final actionWithCooking = testRegistries.fishing.actions.firstWhere(
+          (a) => testRegistries.cooking.cookedForRaw(a.productId) != null,
+          orElse: () => throw StateError(
+            'No fishing action has a matching cooking recipe',
+          ),
+        );
+        _testCookedChance(actionWithCooking);
+        return;
+      }
+
+      _testCookedChance(actionWithJunkAndSpecial);
+    });
+
+    test('raw fish drops normally when fishingCookedChance is 0', () {
+      final action = testRegistries.fishing.actions.firstWhere(
+        (a) => testRegistries.cooking.cookedForRaw(a.productId) != null,
+        orElse: () =>
+            throw StateError('No fishing action has a matching cooking recipe'),
+      );
+      final rawFishId = action.productId;
+      final cookedId = testRegistries.cooking.cookedForRaw(rawFishId)!;
+
+      final state = GlobalState.test(testRegistries);
+      final builder = StateUpdateBuilder(state);
+      final modifiers = StubModifierProvider();
+
+      // Run enough iterations to get drops.
+      for (var i = 0; i < 100; i++) {
+        final random = Random(i);
+        rollAndCollectDrops(
+          builder,
+          action,
+          modifiers,
+          random,
+          const NoSelectedRecipe(),
+        );
+      }
+
+      // Should have raw fish and no cooked fish.
+      expect(
+        builder.state.inventory.countById(rawFishId),
+        greaterThan(0),
+        reason: 'Should get raw fish',
+      );
+      expect(
+        builder.state.inventory.countById(cookedId),
+        equals(0),
+        reason: 'Should not get cooked fish without modifier',
+      );
+    });
+  });
+
+  group('FishingJunkDrop and FishingSpecialDrop types', () {
+    test('allDropsForAction returns tagged fishing drop types', () {
+      final drops = testDrops.allDropsForAction(
+        actionWithJunkAndSpecial,
+        const NoSelectedRecipe(),
+      );
+
+      final junkDrops = drops.whereType<FishingJunkDrop>().toList();
+      final specialDrops = drops.whereType<FishingSpecialDrop>().toList();
+
+      expect(junkDrops.length, equals(1));
+      expect(specialDrops.length, equals(1));
+    });
+
+    test('area without junk has no FishingJunkDrop', () {
+      final drops = testDrops.allDropsForAction(
+        actionNoJunk,
+        const NoSelectedRecipe(),
+      );
+      final junkDrops = drops.whereType<FishingJunkDrop>().toList();
+      expect(junkDrops, isEmpty);
+    });
+  });
+
+  group('CookingRegistry.cookedForRaw', () {
+    test('returns cooked item for raw fish', () {
+      // Raw Shrimp -> Shrimp (cooked)
+      const rawShrimpId = MelvorId('melvorD:Raw_Shrimp');
+      final cookedId = testRegistries.cooking.cookedForRaw(rawShrimpId);
+      expect(cookedId, isNotNull);
+      expect(cookedId!.name, equals('Shrimp'));
+    });
+
+    test('returns null for non-cookable item', () {
+      const normalLogsId = MelvorId('melvorD:Normal_Logs');
+      final cookedId = testRegistries.cooking.cookedForRaw(normalLogsId);
+      expect(cookedId, isNull);
+    });
+  });
+}
+
+/// Helper to test the fishingCookedChance modifier with a given action.
+void _testCookedChance(FishingAction action) {
+  final rawFishId = action.productId;
+  final cookedId = testRegistries.cooking.cookedForRaw(rawFishId)!;
+
+  // Use 100% cooked chance to guarantee replacement.
+  final state = GlobalState.test(testRegistries);
+  final builder = StateUpdateBuilder(state);
+  final modifiers = StubModifierProvider({'fishingCookedChance': 100});
+
+  for (var i = 0; i < 100; i++) {
+    final random = Random(i);
+    rollAndCollectDrops(
+      builder,
+      action,
+      modifiers,
+      random,
+      const NoSelectedRecipe(),
+    );
+  }
+
+  // Should have cooked fish, not raw.
+  expect(
+    builder.state.inventory.countById(cookedId),
+    greaterThan(0),
+    reason: 'Should get cooked fish with 100% fishingCookedChance',
+  );
+  expect(
+    builder.state.inventory.countById(rawFishId),
+    equals(0),
+    reason: 'Should not get raw fish with 100% fishingCookedChance',
+  );
+}


### PR DESCRIPTION
## Summary
- Consume five previously-unused fishing modifiers: `cannotFishJunk`, `fishingSpecialChance`, `bonusFishingSpecialChance`, `fishingAdditionalSpecialItemChance`, and `fishingCookedChance`
- Introduce `FishingJunkDrop` and `FishingSpecialDrop` tagged subtypes of `DropChance` so `rollAndCollectDrops` can apply modifiers to the correct drop type
- Add `CookingRegistry.cookedForRaw()` reverse lookup (raw item -> cooked product) for the cooked chance modifier

## Implementation details
- **cannotFishJunk**: When the modifier value is > 0, `FishingJunkDrop` is skipped entirely in `rollAndCollectDrops`
- **fishingSpecialChance + bonusFishingSpecialChance + fishingAdditionalSpecialItemChance**: All three are summed as percentage-point bonuses to the area's base special item rate on `FishingSpecialDrop`
- **fishingCookedChance**: After a primary fishing product drops, rolls for replacement with the cooked version via `CookingRegistry.cookedForRaw()`. Applied before doubling chance so doubled fish can also be cooked

## Test plan
- [x] `cannotFishJunk` suppresses junk drops when active
- [x] `cannotFishJunk` at 0 allows normal junk drops
- [x] `fishingSpecialChance` increases special item drops
- [x] `bonusFishingSpecialChance` increases special item drops
- [x] `fishingAdditionalSpecialItemChance` increases special item drops
- [x] `fishingCookedChance` replaces raw fish with cooked fish at 100%
- [x] `fishingCookedChance` at 0 produces only raw fish
- [x] `FishingJunkDrop` and `FishingSpecialDrop` types appear in `allDropsForAction`
- [x] `CookingRegistry.cookedForRaw` returns correct cooked item
- [x] `CookingRegistry.cookedForRaw` returns null for non-cookable items
- [x] All 2340 existing tests still pass