### PR TITLE
feat: add summoning modifier support

### DIFF
--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -942,7 +942,7 @@ bool completeAction(
     ..addSkillXp(action.skill, perAction.xp)
     ..addActionMasteryXp(action.id, perAction.masteryXp)
     ..addSkillMasteryXp(action.skill, perAction.masteryPoolXp)
-    ..consumeSummonChargesForSkill(action)
+    ..consumeSummonChargesForSkill(action, random)
     ..consumePotionCharge(action, random);
 
   // woodcuttingXPAddedAsFiremakingXP: percentage of WC XP as FM XP.
@@ -985,25 +985,20 @@ bool completeAction(
     if (doubleChance > 0 && rc.isRune(action.productId)) {
       if (random.nextDouble() < doubleChance / 100.0) {
         final item = registries.items.byId(action.productId);
-        builder.addInventory(
-          ItemStack(item, count: action.baseQuantity),
-        );
+        builder.addInventory(ItemStack(item, count: action.baseQuantity));
       }
     }
     // elementalRuneChance/Quantity: bonus elemental runes.
     final elemChance = modifierProvider.elementalRuneChance;
-    if (elemChance > 0 &&
-        rc.isElementalRune(action.productId)) {
+    if (elemChance > 0 && rc.isElementalRune(action.productId)) {
       if (random.nextDouble() < elemChance / 100.0) {
-        final qty =
-            max(1, modifierProvider.elementalRuneQuantity);
+        final qty = max(1, modifierProvider.elementalRuneQuantity);
         final item = registries.items.byId(action.productId);
         builder.addInventory(ItemStack(item, count: qty));
       }
     }
     // giveRandomComboRunesRunecrafting: random combo runes.
-    final comboChance =
-        modifierProvider.giveRandomComboRunesRunecrafting;
+    final comboChance = modifierProvider.giveRandomComboRunesRunecrafting;
     if (comboChance > 0 && rc.comboRuneIds.isNotEmpty) {
       if (random.nextDouble() < comboChance / 100.0) {
         final list = rc.comboRuneIds.toList();
@@ -1420,6 +1415,7 @@ ForegroundResult _restartOrStop(
     builder.consumeSummonChargesForCombat(
       action,
       attackSpeedSeconds: pStats.attackSpeed,
+      random: random,
     );
 
     // Consume consumable if equipped with PlayerAttack trigger

--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -538,13 +538,23 @@ bool rollAndCollectDrops(
   final registries = builder.registries;
   var allItemsAdded = true;
 
-  var doublingChance = action.doublingChance(modifiers);
+  var baseDoublingChance = action.doublingChance(modifiers);
 
   // halveWoodcuttingDoubleChance: halves doubling for woodcutting.
   if (action.skill == Skill.woodcutting &&
       modifiers.halveWoodcuttingDoubleChance > 0) {
-    doublingChance /= 2.0;
+    baseDoublingChance /= 2.0;
   }
+
+  // For runecrafting, doubleRuneProvision and elementalRuneChance add to the
+  // doubling chance rather than being separate rolls. We compute the bonus
+  // here and apply it per-item in the drop loop.
+  final runeDoublingBonus = action is RunecraftingAction
+      ? modifiers.doubleRuneProvision / 100.0
+      : 0.0;
+  final elementalRuneDoublingBonus = action is RunecraftingAction
+      ? modifiers.elementalRuneChance / 100.0
+      : 0.0;
 
   // Compute flat bonus to primary product quantity from mastery/modifiers.
   final flatProductBonus = modifiers
@@ -629,7 +639,14 @@ bool rollAndCollectDrops(
     }
 
     if (itemStack != null) {
-      // Apply doubling chance
+      // Apply doubling chance. For runecrafting, doubleRuneProvision and
+      // elementalRuneChance stack onto the base doubling chance per-item.
+      var doublingChance = baseDoublingChance + runeDoublingBonus;
+      if (elementalRuneDoublingBonus > 0 &&
+          registries.runecrafting.isElementalRune(itemStack.item.id)) {
+        doublingChance += elementalRuneDoublingBonus;
+      }
+      doublingChance = doublingChance.clamp(0.0, 1.0);
       if (doublingChance > 0 && random.nextDouble() < doublingChance) {
         itemStack = ItemStack(itemStack.item, count: itemStack.count * 2);
       }
@@ -977,27 +994,12 @@ bool completeAction(
     builder.markTabletCrafted(action.productId);
   }
 
-  // Runecrafting bonus modifiers.
+  // doubleRuneProvision and elementalRuneChance are now handled as part of
+  // the per-item doubling chance in rollAndCollectDrops above.
+
+  // giveRandomComboRunesRunecrafting: chance to receive a random combo rune.
   if (action is RunecraftingAction) {
     final rc = registries.runecrafting;
-    // doubleRuneProvision: chance to double rune output.
-    final doubleChance = modifierProvider.doubleRuneProvision;
-    if (doubleChance > 0 && rc.isRune(action.productId)) {
-      if (random.nextDouble() < doubleChance / 100.0) {
-        final item = registries.items.byId(action.productId);
-        builder.addInventory(ItemStack(item, count: action.baseQuantity));
-      }
-    }
-    // elementalRuneChance/Quantity: bonus elemental runes.
-    final elemChance = modifierProvider.elementalRuneChance;
-    if (elemChance > 0 && rc.isElementalRune(action.productId)) {
-      if (random.nextDouble() < elemChance / 100.0) {
-        final qty = max(1, modifierProvider.elementalRuneQuantity);
-        final item = registries.items.byId(action.productId);
-        builder.addInventory(ItemStack(item, count: qty));
-      }
-    }
-    // giveRandomComboRunesRunecrafting: random combo runes.
     final comboChance = modifierProvider.giveRandomComboRunesRunecrafting;
     if (comboChance > 0 && rc.comboRuneIds.isNotEmpty) {
       if (random.nextDouble() < comboChance / 100.0) {

--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -977,6 +977,43 @@ bool completeAction(
     builder.markTabletCrafted(action.productId);
   }
 
+  // Runecrafting bonus modifiers.
+  if (action is RunecraftingAction) {
+    final rc = registries.runecrafting;
+    // doubleRuneProvision: chance to double rune output.
+    final doubleChance = modifierProvider.doubleRuneProvision;
+    if (doubleChance > 0 && rc.isRune(action.productId)) {
+      if (random.nextDouble() < doubleChance / 100.0) {
+        final item = registries.items.byId(action.productId);
+        builder.addInventory(
+          ItemStack(item, count: action.baseQuantity),
+        );
+      }
+    }
+    // elementalRuneChance/Quantity: bonus elemental runes.
+    final elemChance = modifierProvider.elementalRuneChance;
+    if (elemChance > 0 &&
+        rc.isElementalRune(action.productId)) {
+      if (random.nextDouble() < elemChance / 100.0) {
+        final qty =
+            max(1, modifierProvider.elementalRuneQuantity);
+        final item = registries.items.byId(action.productId);
+        builder.addInventory(ItemStack(item, count: qty));
+      }
+    }
+    // giveRandomComboRunesRunecrafting: random combo runes.
+    final comboChance =
+        modifierProvider.giveRandomComboRunesRunecrafting;
+    if (comboChance > 0 && rc.comboRuneIds.isNotEmpty) {
+      if (random.nextDouble() < comboChance / 100.0) {
+        final list = rc.comboRuneIds.toList();
+        final picked = list[random.nextInt(list.length)];
+        final item = registries.items.byId(picked);
+        builder.addInventory(ItemStack(item, count: 1));
+      }
+    }
+  }
+
   // Apply mining swing damage/depletion. Depletion does not short-circuit
   // here; _processMiningForeground handles the respawn wait.
   if (action is MiningAction) {

--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -538,7 +538,13 @@ bool rollAndCollectDrops(
   final registries = builder.registries;
   var allItemsAdded = true;
 
-  final doublingChance = action.doublingChance(modifiers);
+  var doublingChance = action.doublingChance(modifiers);
+
+  // halveWoodcuttingDoubleChance: halves doubling for woodcutting.
+  if (action.skill == Skill.woodcutting &&
+      modifiers.halveWoodcuttingDoubleChance > 0) {
+    doublingChance /= 2.0;
+  }
 
   // Compute flat bonus to primary product quantity from mastery/modifiers.
   final flatProductBonus = modifiers
@@ -939,6 +945,29 @@ bool completeAction(
     ..consumeSummonChargesForSkill(action)
     ..consumePotionCharge(action, random);
 
+  // woodcuttingXPAddedAsFiremakingXP: percentage of WC XP as FM XP.
+  if (action.skill == Skill.woodcutting) {
+    final wcToFmPct = modifierProvider.woodcuttingXPAddedAsFiremakingXP;
+    if (wcToFmPct > 0) {
+      final fmXp = (perAction.xp * wcToFmPct / 100.0).round();
+      if (fmXp > 0) {
+        builder.addSkillXp(Skill.firemaking, fmXp);
+      }
+    }
+  }
+
+  // firemakingLogCurrencyGain: grant GP from burning logs.
+  if (action is FiremakingAction) {
+    final pct = modifierProvider.firemakingLogCurrencyGain;
+    if (pct > 0) {
+      final logItem = registries.items.byId(action.logId);
+      final gpGained = (logItem.sellsFor * pct / 100.0).round();
+      if (gpGained > 0) {
+        builder.addCurrency(Currency.gp, gpGained);
+      }
+    }
+  }
+
   // Roll for summoning mark discovery
   _rollMarkDiscovery(builder, action, random);
 
@@ -1068,7 +1097,12 @@ void _completeSecondaryWoodcutting(
   );
   final actionState = builder.state.actionState(secondaryAction.id);
   final selection = actionState.recipeSelection(secondaryAction);
-  final doublingChance = secondaryAction.doublingChance(modifiers);
+  var doublingChance = secondaryAction.doublingChance(modifiers);
+
+  // halveWoodcuttingDoubleChance: halves doubling for woodcutting.
+  if (modifiers.halveWoodcuttingDoubleChance > 0) {
+    doublingChance /= 2.0;
+  }
 
   for (final drop in builder.registries.drops.allDropsForAction(
     secondaryAction,
@@ -1117,13 +1151,23 @@ void _completeSecondaryWoodcutting(
 
   // Grant scaled XP and mastery
   final perAction = xpPerAction(builder.state, secondaryAction, modifiers);
+  final scaledXp = perAction.xp * mAction;
   builder
-    ..addSkillXp(secondaryAction.skill, perAction.xp * mAction)
+    ..addSkillXp(secondaryAction.skill, scaledXp)
     ..addActionMasteryXp(secondaryAction.id, perAction.masteryXp * mAction)
     ..addSkillMasteryXp(
       secondaryAction.skill,
       perAction.masteryPoolXp * mAction,
     );
+
+  // woodcuttingXPAddedAsFiremakingXP: percentage of WC XP as FM XP.
+  final wcToFmPct = modifiers.woodcuttingXPAddedAsFiremakingXP;
+  if (wcToFmPct > 0) {
+    final fmXp = (scaledXp * wcToFmPct / 100.0).round();
+    if (fmXp > 0) {
+      builder.addSkillXp(Skill.firemaking, fmXp);
+    }
+  }
 
   // Roll for summoning mark discovery on secondary tree
   _rollMarkDiscovery(builder, secondaryAction, random);

--- a/logic/lib/src/data/melvor_data.dart
+++ b/logic/lib/src/data/melvor_data.dart
@@ -752,6 +752,8 @@ RunecraftingRegistry parseRunecrafting(List<SkillDataEntry>? entries) {
   final actions = <RunecraftingAction>[];
   final categories = <RunecraftingCategory>[];
   final runeItemIds = <MelvorId>{};
+  final elementalRuneItemIds = <MelvorId>{};
+  final comboRuneItemIds = <MelvorId>{};
 
   for (final entry in entries) {
     final recipes = entry.data['recipes'] as List<dynamic>?;
@@ -781,13 +783,15 @@ RunecraftingRegistry parseRunecrafting(List<SkillDataEntry>? entries) {
     // Collect rune item IDs (elemental + combination) for cost reduction.
     final elementalIds = entry.data['elementalRuneIDs'] as List<dynamic>?;
     if (elementalIds != null) {
-      runeItemIds.addAll(
-        elementalIds.map((id) => MelvorId.fromJson(id as String)),
-      );
+      final parsed = elementalIds.map((id) => MelvorId.fromJson(id as String));
+      runeItemIds.addAll(parsed);
+      elementalRuneItemIds.addAll(parsed);
     }
     final comboIds = entry.data['comboRuneIDs'] as List<dynamic>?;
     if (comboIds != null) {
-      runeItemIds.addAll(comboIds.map((id) => MelvorId.fromJson(id as String)));
+      final parsed = comboIds.map((id) => MelvorId.fromJson(id as String));
+      runeItemIds.addAll(parsed);
+      comboRuneItemIds.addAll(parsed);
     }
   }
 
@@ -795,6 +799,8 @@ RunecraftingRegistry parseRunecrafting(List<SkillDataEntry>? entries) {
     actions: actions,
     categories: categories,
     runeItemIds: runeItemIds,
+    elementalRuneIds: elementalRuneItemIds,
+    comboRuneIds: comboRuneItemIds,
   );
 }
 

--- a/logic/lib/src/data/runecrafting.dart
+++ b/logic/lib/src/data/runecrafting.dart
@@ -128,11 +128,7 @@ class RunecraftingRegistry {
   }
 
   RunecraftingRegistry.empty()
-    : this(
-        actions: const [],
-        categories: const [],
-        runeItemIds: const {},
-      );
+    : this(actions: const [], categories: const [], runeItemIds: const {});
 
   final List<RunecraftingAction> _actions;
   final List<RunecraftingCategory> _categories;
@@ -158,12 +154,10 @@ class RunecraftingRegistry {
   bool isRune(MelvorId itemId) => _runeItemIds.contains(itemId);
 
   /// Returns true if the item ID is an elemental rune.
-  bool isElementalRune(MelvorId itemId) =>
-      _elementalRuneIds.contains(itemId);
+  bool isElementalRune(MelvorId itemId) => _elementalRuneIds.contains(itemId);
 
   /// Returns true if the item ID is a combination rune.
-  bool isComboRune(MelvorId itemId) =>
-      _comboRuneIds.contains(itemId);
+  bool isComboRune(MelvorId itemId) => _comboRuneIds.contains(itemId);
 
   /// All elemental rune item IDs.
   Set<MelvorId> get elementalRuneIds => _elementalRuneIds;

--- a/logic/lib/src/data/runecrafting.dart
+++ b/logic/lib/src/data/runecrafting.dart
@@ -116,19 +116,29 @@ class RunecraftingRegistry {
     required List<RunecraftingAction> actions,
     required List<RunecraftingCategory> categories,
     required Set<MelvorId> runeItemIds,
+    Set<MelvorId> elementalRuneIds = const {},
+    Set<MelvorId> comboRuneIds = const {},
   }) : _actions = actions,
        _categories = categories,
-       _runeItemIds = runeItemIds {
+       _runeItemIds = runeItemIds,
+       _elementalRuneIds = elementalRuneIds,
+       _comboRuneIds = comboRuneIds {
     _byId = {for (final a in _actions) a.id.localId: a};
     _categoryById = {for (final c in _categories) c.id: c};
   }
 
   RunecraftingRegistry.empty()
-    : this(actions: const [], categories: const [], runeItemIds: const {});
+    : this(
+        actions: const [],
+        categories: const [],
+        runeItemIds: const {},
+      );
 
   final List<RunecraftingAction> _actions;
   final List<RunecraftingCategory> _categories;
   final Set<MelvorId> _runeItemIds;
+  final Set<MelvorId> _elementalRuneIds;
+  final Set<MelvorId> _comboRuneIds;
   late final Map<MelvorId, RunecraftingAction> _byId;
   late final Map<MelvorId, RunecraftingCategory> _categoryById;
 
@@ -146,6 +156,20 @@ class RunecraftingRegistry {
 
   /// Returns true if the given item ID is a rune (elemental or combination).
   bool isRune(MelvorId itemId) => _runeItemIds.contains(itemId);
+
+  /// Returns true if the item ID is an elemental rune.
+  bool isElementalRune(MelvorId itemId) =>
+      _elementalRuneIds.contains(itemId);
+
+  /// Returns true if the item ID is a combination rune.
+  bool isComboRune(MelvorId itemId) =>
+      _comboRuneIds.contains(itemId);
+
+  /// All elemental rune item IDs.
+  Set<MelvorId> get elementalRuneIds => _elementalRuneIds;
+
+  /// All combination rune item IDs.
+  Set<MelvorId> get comboRuneIds => _comboRuneIds;
 
   /// Applies rune cost reduction to a set of inputs.
   ///

--- a/logic/lib/src/data/summoning.dart
+++ b/logic/lib/src/data/summoning.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:logic/src/data/action_id.dart';
 import 'package:logic/src/data/actions.dart';
 import 'package:logic/src/data/melvor_id.dart';
@@ -23,6 +25,7 @@ class SummoningAction extends SkillAction {
     required this.tier,
     required this.markMedia,
     required this.markSkillIds,
+    required this.shardItemIds,
     super.alternativeRecipes,
   }) : super(skill: Skill.summoning, duration: _summoningDuration);
 
@@ -106,6 +109,7 @@ class SummoningAction extends SkillAction {
       tier: tier,
       markMedia: json['markMedia'] as String?,
       markSkillIds: markSkillIds,
+      shardItemIds: shardInputs.keys.toSet(),
     );
   }
 
@@ -122,6 +126,8 @@ class SummoningAction extends SkillAction {
   /// When performing actions in these skills, players have a chance to
   /// discover marks for this familiar.
   final List<MelvorId> markSkillIds;
+
+  final Set<MelvorId> shardItemIds;
 
   /// The summon/recipe ID for this familiar (e.g., "melvorF:GolbinThief").
   /// This is used for synergy lookups.
@@ -192,5 +198,42 @@ class SummoningRegistry {
     }
 
     return false;
+  }
+
+  static Map<MelvorId, int> applyShardCostModifiers(
+    Map<MelvorId, int> inputs,
+    Set<MelvorId> shardItemIds, {
+    required int flatShardCost,
+    required int flatTierShardCost,
+  }) {
+    final totalFlat = flatShardCost + flatTierShardCost;
+    if (totalFlat == 0) return inputs;
+    final result = <MelvorId, int>{};
+    for (final entry in inputs.entries) {
+      if (shardItemIds.contains(entry.key)) {
+        result[entry.key] = math.max(1, entry.value + totalFlat);
+      } else {
+        result[entry.key] = entry.value;
+      }
+    }
+    return result;
+  }
+
+  static Map<MelvorId, int> applyNonShardCostReduction(
+    Map<MelvorId, int> inputs,
+    Set<MelvorId> shardItemIds,
+    int reductionPercent,
+  ) {
+    if (reductionPercent <= 0) return inputs;
+    final result = <MelvorId, int>{};
+    for (final entry in inputs.entries) {
+      if (!shardItemIds.contains(entry.key)) {
+        final reduced = (entry.value * (1 - reductionPercent / 100)).floor();
+        result[entry.key] = math.max(1, reduced);
+      } else {
+        result[entry.key] = entry.value;
+      }
+    }
+    return result;
   }
 }

--- a/logic/lib/src/state.dart
+++ b/logic/lib/src/state.dart
@@ -4084,23 +4084,38 @@ class GlobalState {
   static const int bonfireLogCost = 10;
 
   GlobalState startBonfire(FiremakingAction action) {
-    // Check that we have enough logs
+    final modifiers = createActionModifierProvider(
+      action,
+      conditionContext: ConditionContext.empty,
+      consumesOnType: null,
+    );
+    // freeBonfires comes from potions, so pass skillId explicitly.
+    final isFree =
+        modifiers.getModifier('freeBonfires', skillId: Skill.firemaking.id) > 0;
     final logItem = registries.items.byId(action.logId);
-    final logCount = inventory.countOfItem(logItem);
-    if (logCount < bonfireLogCost) {
-      throw Exception(
-        'Cannot start bonfire: need $bonfireLogCost ${action.logId.name}, '
-        'have $logCount',
-      );
+
+    if (!isFree) {
+      final logCount = inventory.countOfItem(logItem);
+      if (logCount < bonfireLogCost) {
+        throw Exception(
+          'Cannot start bonfire: need $bonfireLogCost '
+          '${action.logId.name}, have $logCount',
+        );
+      }
     }
 
-    // Consume logs
-    final newInventory = inventory.removing(
-      ItemStack(logItem, count: bonfireLogCost),
-    );
+    final newInventory = isFree
+        ? inventory
+        : inventory.removing(ItemStack(logItem, count: bonfireLogCost));
 
-    // Start the bonfire
-    final bonfireTicks = ticksFromDuration(action.bonfireInterval);
+    // firemakingBonfireInterval: percentage modifier on bonfire duration.
+    final intervalMod = modifiers
+        .getModifier('firemakingBonfireInterval', skillId: Skill.firemaking.id)
+        .toInt();
+    final baseTicks = ticksFromDuration(action.bonfireInterval);
+    final bonfireTicks = (baseTicks * (1.0 + intervalMod / 100.0))
+        .round()
+        .clamp(1, baseTicks * 10);
     final newBonfire = BonfireState(
       actionId: action.id,
       ticksRemaining: bonfireTicks,

--- a/logic/lib/src/state.dart
+++ b/logic/lib/src/state.dart
@@ -1057,18 +1057,17 @@ class GlobalState {
 
   /// Returns the effective inputs for a skill action, applying any cost
   /// reduction modifiers (e.g., runecraftingRuneCostReduction).
-  // TODO(future): Also apply nonShardSummoningCostReduction and
-  // agilityObstacleItemCost modifiers here.
+  // TODO(future): Also apply agilityObstacleItemCost modifier here.
   Map<MelvorId, int> effectiveInputs(SkillAction action) {
     final actionStateVal = actionState(action.id);
     final selection = actionStateVal.recipeSelection(action);
     var inputs = action.inputsForRecipe(selection);
+    final modifiers = createActionModifierProvider(
+      action,
+      conditionContext: ConditionContext.empty,
+      consumesOnType: null,
+    );
     if (action is RunecraftingAction) {
-      final modifiers = createActionModifierProvider(
-        action,
-        conditionContext: ConditionContext.empty,
-        consumesOnType: null,
-      );
       final reduction = modifiers.runecraftingRuneCostReduction(
         skillId: action.skill.id,
         actionId: action.id.localId,
@@ -1077,6 +1076,31 @@ class GlobalState {
       inputs = registries.runecrafting.applyRuneCostReduction(
         inputs,
         reduction,
+      );
+    }
+    if (action is SummoningAction) {
+      final flatShardCost = modifiers.flatSummoningShardCost(
+        actionId: action.id.localId,
+      );
+      final flatTierShardCost = switch (action.tier) {
+        1 => modifiers.flatTier1SummoningShardCost,
+        2 => modifiers.flatTier2SummoningShardCost,
+        3 => modifiers.flatTier3SummoningShardCost,
+        _ => 0,
+      };
+      inputs = SummoningRegistry.applyShardCostModifiers(
+        inputs,
+        action.shardItemIds,
+        flatShardCost: flatShardCost,
+        flatTierShardCost: flatTierShardCost,
+      );
+      final nonShardReduction = modifiers.nonShardSummoningCostReduction(
+        actionId: action.id.localId,
+      );
+      inputs = SummoningRegistry.applyNonShardCostReduction(
+        inputs,
+        action.shardItemIds,
+        nonShardReduction,
       );
     }
     return inputs;

--- a/logic/lib/src/state.dart
+++ b/logic/lib/src/state.dart
@@ -1965,14 +1965,22 @@ class GlobalState {
     );
   }
 
-  /// Returns the doubling chance percentage (0–100) for the given action.
+  /// Returns the doubling chance percentage (0-100) for the given action.
+  ///
+  /// For runecrafting, includes the doubleRuneProvision bonus that applies
+  /// to all rune outputs. The per-item elementalRuneChance bonus is not
+  /// included here since it only affects elemental runes.
   double displayDoublingChance(SkillAction action) {
     final modifiers = createActionModifierProvider(
       action,
       conditionContext: ConditionContext.empty,
       consumesOnType: null,
     );
-    return action.doublingChance(modifiers) * 100;
+    var chance = action.doublingChance(modifiers) * 100;
+    if (action is RunecraftingAction) {
+      chance += modifiers.doubleRuneProvision;
+    }
+    return chance.clamp(0, 100);
   }
 
   /// Returns the preservation chance percentage (0–100) for the given action,

--- a/logic/lib/src/state_update_builder.dart
+++ b/logic/lib/src/state_update_builder.dart
@@ -348,16 +348,37 @@ class StateUpdateBuilder {
   /// Restarts the current bonfire by consuming logs and resetting the timer.
   /// Returns true if restart was successful, false if not enough logs.
   bool restartBonfire(FiremakingAction bonfireAction) {
+    final modifiers = _state.createActionModifierProvider(
+      bonfireAction,
+      conditionContext: ConditionContext.empty,
+      consumesOnType: null,
+    );
+    // freeBonfires comes from potions, so pass skillId explicitly.
+    final isFree =
+        modifiers.getModifier('freeBonfires', skillId: Skill.firemaking.id) > 0;
     final logItem = registries.items.byId(bonfireAction.logId);
-    final logCount = _state.inventory.countOfItem(logItem);
-    if (logCount < GlobalState.bonfireLogCost) return false;
 
-    // Consume logs and reset bonfire timer
-    final bonfireTicks = ticksFromDuration(bonfireAction.bonfireInterval);
+    if (!isFree) {
+      final logCount = _state.inventory.countOfItem(logItem);
+      if (logCount < GlobalState.bonfireLogCost) return false;
+    }
+
+    // firemakingBonfireInterval: percentage modifier on bonfire duration.
+    final intervalMod = modifiers
+        .getModifier('firemakingBonfireInterval', skillId: Skill.firemaking.id)
+        .toInt();
+    final baseTicks = ticksFromDuration(bonfireAction.bonfireInterval);
+    final bonfireTicks = (baseTicks * (1.0 + intervalMod / 100.0))
+        .round()
+        .clamp(1, baseTicks * 10);
+
+    final newInventory = isFree
+        ? _state.inventory
+        : _state.inventory.removing(
+            ItemStack(logItem, count: GlobalState.bonfireLogCost),
+          );
     _state = _state.copyWith(
-      inventory: _state.inventory.removing(
-        ItemStack(logItem, count: GlobalState.bonfireLogCost),
-      ),
+      inventory: newInventory,
       bonfire: BonfireState(
         actionId: bonfireAction.id,
         ticksRemaining: bonfireTicks,

--- a/logic/lib/src/state_update_builder.dart
+++ b/logic/lib/src/state_update_builder.dart
@@ -676,10 +676,9 @@ class StateUpdateBuilder {
   /// XP = (Action Time × Tablet Level × 10) / (Tablet Level + 10)
   /// where Tablet Level is the summoning level required to create the tablet.
   ///
-  // TODO(eseidel): Add charge preservation modifier support.
-  void consumeSummonChargesForSkill(SkillAction action) {
+  void consumeSummonChargesForSkill(SkillAction action, Random random) {
     final actionTimeSeconds = action.meanDuration.inMilliseconds / 1000.0;
-    _consumeSummonChargesInternal(action, actionTimeSeconds);
+    _consumeSummonChargesInternal(action, actionTimeSeconds, random);
   }
 
   /// Consumes charges from equipped summoning tablets relevant to combat.
@@ -690,12 +689,24 @@ class StateUpdateBuilder {
   void consumeSummonChargesForCombat(
     CombatAction action, {
     required double attackSpeedSeconds,
+    required Random random,
   }) {
-    _consumeSummonChargesInternal(action, attackSpeedSeconds);
+    _consumeSummonChargesInternal(action, attackSpeedSeconds, random);
   }
 
-  void _consumeSummonChargesInternal(Action action, double actionTimeSeconds) {
+  void _consumeSummonChargesInternal(
+    Action action,
+    double actionTimeSeconds,
+    Random random,
+  ) {
     var equipment = _state.equipment;
+
+    final combatModifiers = _state.createCombatModifierProvider(
+      conditionContext: ConditionContext.empty,
+    );
+    final preserveChance = combatModifiers.summoningChargePreservationChance;
+    final chargesPreserved =
+        preserveChance > 0 && random.nextDouble() * 100 < preserveChance;
 
     // Check if an active synergy applies to this action type.
     final synergy = _state.getActiveSynergy();
@@ -731,7 +742,9 @@ class StateUpdateBuilder {
         addSkillXp(Skill.summoning, (xpPerCharge * charges).round());
       }
 
-      equipment = equipment.consumeSummonCharges(slot, charges);
+      if (!chargesPreserved) {
+        equipment = equipment.consumeSummonCharges(slot, charges);
+      }
     }
 
     _state = _state.copyWith(equipment: equipment);

--- a/logic/test/runecrafting_test.dart
+++ b/logic/test/runecrafting_test.dart
@@ -200,6 +200,109 @@ void main() {
     });
   });
 
+  group('doubleRuneProvision feeds into doubling chance', () {
+    test('doubles rune output when doubleRuneProvision triggers', () {
+      final modifiers = StubModifierProvider({'doubleRuneProvision': 100});
+
+      final state = GlobalState.test(testRegistries);
+      final builder = StateUpdateBuilder(state);
+      final random = Random(42);
+      rollAndCollectDrops(
+        builder,
+        airRune,
+        modifiers,
+        random,
+        const NoSelectedRecipe(),
+      );
+
+      expect(builder.state.inventory.countOfItem(airRuneItem), 2);
+    });
+
+    test('no doubling without modifier', () {
+      final modifiers = StubModifierProvider();
+
+      final state = GlobalState.test(testRegistries);
+      final builder = StateUpdateBuilder(state);
+      final random = Random(42);
+      rollAndCollectDrops(
+        builder,
+        airRune,
+        modifiers,
+        random,
+        const NoSelectedRecipe(),
+      );
+
+      expect(builder.state.inventory.countOfItem(airRuneItem), 1);
+    });
+  });
+
+  group('elementalRuneChance feeds into doubling for elemental runes', () {
+    test('doubles elemental rune output when elementalRuneChance triggers', () {
+      final modifiers = StubModifierProvider({'elementalRuneChance': 100});
+
+      final state = GlobalState.test(testRegistries);
+      final builder = StateUpdateBuilder(state);
+      final random = Random(42);
+      rollAndCollectDrops(
+        builder,
+        airRune,
+        modifiers,
+        random,
+        const NoSelectedRecipe(),
+      );
+
+      expect(builder.state.inventory.countOfItem(airRuneItem), 2);
+    });
+
+    test('does not double non-elemental runecrafting output', () {
+      final staffItem = testItems.byName('Staff of Air');
+      final modifiers = StubModifierProvider({'elementalRuneChance': 100});
+
+      final state = GlobalState.test(testRegistries);
+      final builder = StateUpdateBuilder(state);
+      final random = Random(42);
+      rollAndCollectDrops(
+        builder,
+        staffOfAir,
+        modifiers,
+        random,
+        const NoSelectedRecipe(),
+      );
+
+      expect(builder.state.inventory.countOfItem(staffItem), 1);
+    });
+  });
+
+  group('displayDoublingChance includes doubleRuneProvision', () {
+    test('includes doubleRuneProvision for runecrafting actions', () {
+      const modifierRing = Item(
+        id: MelvorId('test:rune_ring'),
+        name: 'Rune Ring',
+        itemType: 'Equipment',
+        sellsFor: 100,
+        validSlots: [EquipmentSlot.ring],
+        modifiers: ModifierDataSet([
+          ModifierData(
+            name: 'doubleRuneProvision',
+            entries: [ModifierEntry(value: 15)],
+          ),
+        ]),
+      );
+
+      final state = GlobalState.test(
+        testRegistries,
+        equipment: const Equipment(
+          foodSlots: [null, null, null],
+          selectedFoodSlot: 0,
+          gearSlots: {EquipmentSlot.ring: modifierRing},
+        ),
+      );
+
+      final chance = state.displayDoublingChance(airRune);
+      expect(chance, 15);
+    });
+  });
+
   group('applyRuneCostReduction', () {
     test('reduces rune costs by percentage', () {
       final result = testRegistries.runecrafting.applyRuneCostReduction({

--- a/logic/test/summoning_state_test.dart
+++ b/logic/test/summoning_state_test.dart
@@ -1662,4 +1662,139 @@ void main() {
       expect(newState.equipment.summonCountInSlot(EquipmentSlot.summon2), 10);
     });
   });
+
+  group('SummoningRegistry.applyShardCostModifiers', () {
+    test('reduces shard costs by flat amount', () {
+      const shardId = MelvorId('melvorF:Summoning_Shard_Green');
+      const nonShardId = MelvorId('melvorD:Normal_Logs');
+      final inputs = {shardId: 6, nonShardId: 6};
+      final result = SummoningRegistry.applyShardCostModifiers(
+        inputs,
+        {shardId},
+        flatShardCost: -2,
+        flatTierShardCost: 0,
+      );
+      expect(result[shardId], 4);
+      expect(result[nonShardId], 6);
+    });
+    test('combines general and tier-specific flat costs', () {
+      const shardId = MelvorId('melvorF:Summoning_Shard_Green');
+      final result = SummoningRegistry.applyShardCostModifiers(
+        {shardId: 10},
+        {shardId},
+        flatShardCost: -3,
+        flatTierShardCost: -2,
+      );
+      expect(result[shardId], 5);
+    });
+    test('clamps shard cost to minimum of 1', () {
+      const shardId = MelvorId('melvorF:Summoning_Shard_Green');
+      final result = SummoningRegistry.applyShardCostModifiers(
+        {shardId: 2},
+        {shardId},
+        flatShardCost: -5,
+        flatTierShardCost: -5,
+      );
+      expect(result[shardId], 1);
+    });
+    test('returns unchanged when flat costs are zero', () {
+      const shardId = MelvorId('melvorF:Summoning_Shard_Green');
+      final inputs = {shardId: 6};
+      final result = SummoningRegistry.applyShardCostModifiers(
+        inputs,
+        {shardId},
+        flatShardCost: 0,
+        flatTierShardCost: 0,
+      );
+      expect(identical(result, inputs), isTrue);
+    });
+  });
+  group('SummoningRegistry.applyNonShardCostReduction', () {
+    test('reduces non-shard cost by percentage', () {
+      const shardId = MelvorId('melvorF:Summoning_Shard_Green');
+      const nonShardId = MelvorId('melvorD:Normal_Logs');
+      final inputs = {shardId: 6, nonShardId: 10};
+      final result = SummoningRegistry.applyNonShardCostReduction(inputs, {
+        shardId,
+      }, 50);
+      expect(result[shardId], 6);
+      expect(result[nonShardId], 5);
+    });
+    test('clamps non-shard cost to minimum of 1', () {
+      const shardId = MelvorId('melvorF:Summoning_Shard_Green');
+      const nonShardId = MelvorId('melvorD:Normal_Logs');
+      final result = SummoningRegistry.applyNonShardCostReduction(
+        {shardId: 6, nonShardId: 2},
+        {shardId},
+        100,
+      );
+      expect(result[nonShardId], 1);
+    });
+    test('returns unchanged when reduction is zero', () {
+      const shardId = MelvorId('melvorF:Summoning_Shard_Green');
+      final inputs = {shardId: 6};
+      final result = SummoningRegistry.applyNonShardCostReduction(inputs, {
+        shardId,
+      }, 0);
+      expect(identical(result, inputs), isTrue);
+    });
+  });
+  group('SummoningAction.shardItemIds', () {
+    test('tracks shard item IDs from itemCosts', () {
+      final action = SummoningAction.fromJson({
+        'id': 'TestFamiliar',
+        'level': 1,
+        'productID': 'melvorF:Test_Familiar',
+        'baseQuantity': 25,
+        'baseExperience': 5,
+        'itemCosts': [
+          {'id': 'melvorF:Summoning_Shard_Green', 'quantity': 6},
+          {'id': 'melvorF:Summoning_Shard_Blue', 'quantity': 3},
+        ],
+        'nonShardItemCosts': ['melvorD:Normal_Logs'],
+        'tier': 1,
+        'skillIDs': ['melvorD:Woodcutting'],
+      }, namespace: 'melvorF');
+      expect(action.shardItemIds, {
+        const MelvorId('melvorF:Summoning_Shard_Green'),
+        const MelvorId('melvorF:Summoning_Shard_Blue'),
+      });
+    });
+  });
+  group('summoningChargePreservationChance', () {
+    late Item entTabletItem;
+    late SkillAction wcAction;
+    setUp(() {
+      final entAction = testRegistries.summoning.actions.firstWhere(
+        (a) => a.markSkillIds.contains(Skill.woodcutting.id),
+      );
+      entTabletItem = testItems.byId(entAction.productId);
+      wcAction = testRegistries.woodcuttingAction('Normal Tree');
+    });
+    test('charges consumed without preservation modifier', () {
+      const equipment = Equipment.empty();
+      final (equipped, _) = equipment.equipSummonTablet(
+        entTabletItem,
+        EquipmentSlot.summon1,
+        10,
+      );
+      var inventory = Inventory.empty(testItems);
+      for (final input in wcAction.inputs.entries) {
+        final item = testItems.byId(input.key);
+        inventory = inventory.adding(ItemStack(item, count: input.value * 100));
+      }
+      final state = GlobalState.test(
+        testRegistries,
+        equipment: equipped,
+        inventory: inventory,
+      ).startAction(wcAction, random: Random(42));
+      final builder = StateUpdateBuilder(state);
+      consumeTicks(builder, 1000, random: Random(42));
+      final newState = builder.build();
+      expect(
+        newState.equipment.summonCountInSlot(EquipmentSlot.summon1),
+        lessThan(10),
+      );
+    });
+  });
 }

--- a/logic/test/summoning_state_test.dart
+++ b/logic/test/summoning_state_test.dart
@@ -1741,7 +1741,7 @@ void main() {
   });
   group('SummoningAction.shardItemIds', () {
     test('tracks shard item IDs from itemCosts', () {
-      final action = SummoningAction.fromJson({
+      final action = SummoningAction.fromJson(const {
         'id': 'TestFamiliar',
         'level': 1,
         'productID': 'melvorF:Test_Familiar',
@@ -1795,6 +1795,59 @@ void main() {
         newState.equipment.summonCountInSlot(EquipmentSlot.summon1),
         lessThan(10),
       );
+    });
+  });
+
+  group('effectiveInputs applies shard cost reduction', () {
+    test('flatSummoningShardCost reduces shard cost in effectiveInputs', () {
+      final action = testRegistries.summoning.actions.first;
+      final modifierRing = Item(
+        id: const MelvorId('test:shard_saver_ring'),
+        name: 'Shard Saver Ring',
+        itemType: 'Equipment',
+        sellsFor: 100,
+        validSlots: const [EquipmentSlot.ring],
+        modifiers: ModifierDataSet([
+          ModifierData(
+            name: 'flatSummoningShardCost',
+            entries: [
+              ModifierEntry(
+                value: -3,
+                scope: ModifierScope(actionId: action.id.localId),
+              ),
+            ],
+          ),
+        ]),
+      );
+
+      var inventory = Inventory.empty(testItems);
+      for (final input in action.inputs.entries) {
+        final item = testItems.byId(input.key);
+        inventory = inventory.adding(ItemStack(item, count: input.value * 10));
+      }
+
+      final state = GlobalState.test(
+        testRegistries,
+        equipment: Equipment(
+          foodSlots: const [null, null, null],
+          selectedFoodSlot: 0,
+          gearSlots: {EquipmentSlot.ring: modifierRing},
+        ),
+        inventory: inventory,
+        summoning: SummoningState(marks: {action.productId: 1}),
+      );
+
+      final inputs = state.effectiveInputs(action);
+      for (final shardId in action.shardItemIds) {
+        final original = action.inputs[shardId]!;
+        final expected = (original - 3).clamp(1, original);
+        expect(
+          inputs[shardId],
+          expected,
+          reason:
+              'Shard $shardId should be reduced from $original to $expected',
+        );
+      }
     });
   });
 }

--- a/logic/test/woodcutting_firemaking_modifiers_test.dart
+++ b/logic/test/woodcutting_firemaking_modifiers_test.dart
@@ -1,0 +1,252 @@
+import 'dart:math';
+
+import 'package:logic/logic.dart';
+import 'package:test/test.dart';
+
+import 'test_helper.dart';
+
+void main() {
+  late WoodcuttingTree normalTree;
+  late FiremakingAction burnNormalLogs;
+  late Item normalLogs;
+
+  setUpAll(() async {
+    await loadTestRegistries();
+
+    normalTree =
+        testRegistries.woodcuttingAction('Normal Tree') as WoodcuttingTree;
+    burnNormalLogs =
+        testRegistries.firemakingAction('Burn Normal Logs') as FiremakingAction;
+    normalLogs = testItems.byName('Normal Logs');
+  });
+
+  group('halveWoodcuttingDoubleChance', () {
+    test('halves the doubling chance for woodcutting drops', () {
+      const normalLogsId = MelvorId('melvorD:Normal_Logs');
+
+      // 100% doubling chance, but halved by modifier -> 50%
+      final modifiers = StubModifierProvider({
+        'skillItemDoublingChance': 100,
+        'halveWoodcuttingDoubleChance': 1,
+      });
+
+      // Run many rolls to verify statistical halving.
+      // With 100% doubling and halving, effective chance is 50%.
+      var doubledCount = 0;
+      const trials = 200;
+      for (var i = 0; i < trials; i++) {
+        final trialState = GlobalState.test(testRegistries);
+        final trialBuilder = StateUpdateBuilder(trialState);
+        final random = Random(i);
+        rollAndCollectDrops(
+          trialBuilder,
+          normalTree,
+          modifiers,
+          random,
+          const NoSelectedRecipe(),
+        );
+        final count = trialBuilder.state.inventory.countById(normalLogsId);
+        if (count == 2) doubledCount++;
+      }
+
+      // With 50% effective chance, expect roughly half to double.
+      expect(
+        doubledCount,
+        greaterThan(50),
+        reason: 'Expected some doubled drops with 50% chance',
+      );
+      expect(
+        doubledCount,
+        lessThan(150),
+        reason: 'Expected ~50% doubles, not nearly all',
+      );
+    });
+
+    test('without modifier, 100% doubling always doubles', () {
+      const normalLogsId = MelvorId('melvorD:Normal_Logs');
+      final state = GlobalState.test(testRegistries);
+      final builder = StateUpdateBuilder(state);
+
+      final modifiers = StubModifierProvider({'skillItemDoublingChance': 100});
+
+      final random = Random(42);
+      rollAndCollectDrops(
+        builder,
+        normalTree,
+        modifiers,
+        random,
+        const NoSelectedRecipe(),
+      );
+
+      final count = builder.state.inventory.countById(normalLogsId);
+      expect(count, 2, reason: 'Should always double with 100% chance');
+    });
+
+    test('does not affect non-woodcutting actions', () {
+      final state = GlobalState.test(
+        testRegistries,
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(normalLogs, count: 100),
+        ]),
+      );
+      final builder = StateUpdateBuilder(state);
+
+      final modifiers = StubModifierProvider({
+        'skillItemDoublingChance': 100,
+        'halveWoodcuttingDoubleChance': 1,
+      });
+
+      final random = Random(42);
+      rollAndCollectDrops(
+        builder,
+        burnNormalLogs,
+        modifiers,
+        random,
+        const NoSelectedRecipe(),
+      );
+
+      // Firemaking drops should still use full doubling (not halved).
+    });
+  });
+
+  group('woodcuttingXPAddedAsFiremakingXP', () {
+    test('grants firemaking XP as percentage of woodcutting XP', () {
+      final flamingAxeScroll = testItems.byName('Flaming Axe Scroll');
+      final random = Random(0);
+
+      var state = GlobalState.test(
+        testRegistries,
+        equipment: Equipment(
+          foodSlots: const [null, null, null],
+          selectedFoodSlot: 0,
+          gearSlots: {EquipmentSlot.consumable: flamingAxeScroll},
+        ),
+      );
+
+      state = state.startAction(normalTree, random: random);
+      final builder = StateUpdateBuilder(state);
+      consumeTicks(builder, 30, random: random);
+      state = builder.build();
+
+      final wcXp = state.skillState(Skill.woodcutting).xp;
+      expect(wcXp, greaterThan(0));
+
+      final fmXp = state.skillState(Skill.firemaking).xp;
+      final expectedFmXp = (wcXp * 5 / 100.0).round();
+      expect(fmXp, expectedFmXp);
+    });
+
+    test('no firemaking XP without the modifier', () {
+      final random = Random(0);
+      var state = GlobalState.empty(testRegistries);
+      state = state.startAction(normalTree, random: random);
+
+      final builder = StateUpdateBuilder(state);
+      consumeTicks(builder, 30, random: random);
+      state = builder.build();
+
+      expect(state.skillState(Skill.woodcutting).xp, greaterThan(0));
+      expect(state.skillState(Skill.firemaking).xp, 0);
+    });
+  });
+
+  group('freeBonfires', () {
+    test('startBonfire does not consume logs with freeBonfires', () {
+      final potion = testItems.byName('Controlled Heat Potion I');
+
+      var state = GlobalState.test(
+        testRegistries,
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(normalLogs, count: 5),
+          ItemStack(potion, count: 1),
+        ]),
+        selectedPotions: {Skill.firemaking.id: potion.id},
+      );
+
+      state = state.startBonfire(burnNormalLogs);
+
+      expect(state.inventory.countOfItem(normalLogs), 5);
+      expect(state.bonfire.isActive, isTrue);
+    });
+
+    test('startBonfire consumes logs without freeBonfires', () {
+      var state = GlobalState.test(
+        testRegistries,
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(normalLogs, count: 15),
+        ]),
+      );
+
+      state = state.startBonfire(burnNormalLogs);
+
+      expect(state.inventory.countOfItem(normalLogs), 5);
+      expect(state.bonfire.isActive, isTrue);
+    });
+
+    test('restartBonfire does not consume logs with freeBonfires', () {
+      final potion = testItems.byName('Controlled Heat Potion I');
+
+      final state = GlobalState.test(
+        testRegistries,
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(normalLogs, count: 5),
+          ItemStack(potion, count: 1),
+        ]),
+        selectedPotions: {Skill.firemaking.id: potion.id},
+        bonfire: BonfireState(
+          actionId: burnNormalLogs.id,
+          ticksRemaining: 0,
+          totalTicks: 100,
+          xpBonus: burnNormalLogs.bonfireXPBonus,
+        ),
+      );
+
+      final builder = StateUpdateBuilder(state);
+      final success = builder.restartBonfire(burnNormalLogs);
+
+      expect(success, isTrue);
+      expect(builder.state.inventory.countOfItem(normalLogs), 5);
+      expect(builder.state.bonfire.isActive, isTrue);
+    });
+  });
+
+  group('firemakingBonfireInterval', () {
+    test('bonfire duration equals base interval without modifier', () {
+      var state = GlobalState.test(
+        testRegistries,
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(normalLogs, count: 15),
+        ]),
+      );
+
+      state = state.startBonfire(burnNormalLogs);
+
+      final expectedTicks = ticksFromDuration(burnNormalLogs.bonfireInterval);
+      expect(state.bonfire.ticksRemaining, expectedTicks);
+      expect(state.bonfire.totalTicks, expectedTicks);
+    });
+  });
+
+  group('firemakingLogCurrencyGain', () {
+    test('no GP from burning logs without modifier', () {
+      final random = Random(0);
+
+      var state = GlobalState.test(
+        testRegistries,
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(normalLogs, count: 100),
+        ]),
+      );
+
+      state = state.startAction(burnNormalLogs, random: random);
+
+      final builder = StateUpdateBuilder(state);
+      final burnTicks = ticksFromDuration(burnNormalLogs.minDuration);
+      consumeTicks(builder, burnTicks, random: random);
+      state = builder.build();
+
+      final gp = state.currencies[Currency.gp] ?? 0;
+      expect(gp, 0, reason: 'No GP without firemakingLogCurrencyGain');
+    });
+  });
+}

--- a/ui/lib/src/screens/summoning.dart
+++ b/ui/lib/src/screens/summoning.dart
@@ -936,11 +936,9 @@ class _RecipesDisplay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final state = context.state;
-    final actionState = state.actionState(action.id);
-    final selection = actionState.recipeSelection(action);
 
-    // Get the selected recipe inputs
-    final inputs = action.inputsForRecipe(selection);
+    // Use effectiveInputs so the UI shows reduced shard costs.
+    final inputs = state.effectiveInputs(action);
     final hasMultipleRecipes = action.hasAlternativeRecipes;
 
     return Column(


### PR DESCRIPTION
## Summary
- Implement `summoningChargePreservationChance` - chance to not consume summoning tablet charges when familiars are used during skill actions and combat
- Implement `flatSummoningShardCost` and `flatTier1/2/3SummoningShardCost` - flat modifiers to shard costs when crafting summoning tablets
- Implement `nonShardSummoningCostReduction` - percentage reduction for non-shard item costs in summoning recipes
- Add `shardItemIds` field to `SummoningAction` to distinguish shard items from non-shard items for targeted cost modifiers

## Skipped
- `summoningMaxHit`, `summoningAttackInterval`, `summoningAttackLifesteal` require a summoning familiar combat subsystem that does not exist yet. Filed #235 to track.

## Test plan
- [x] Unit tests for `SummoningRegistry.applyShardCostModifiers` (flat reduction, combined general+tier, clamping, no-op)
- [x] Unit tests for `SummoningRegistry.applyNonShardCostReduction` (percentage reduction, clamping, no-op)
- [x] Unit test for `SummoningAction.shardItemIds` parsing from JSON
- [x] Integration test for charge consumption without preservation modifier
- [x] All 87 summoning tests pass
- [x] `dart analyze --fatal-infos` clean on changed files