### PR TITLE
feat: add global item doubling and XP modifiers

### DIFF
--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -506,6 +506,16 @@ XpPerAction xpPerAction(
   // Apply skillXP modifier (percentage points, e.g., -10 = 10% reduction)
   var xpModifier = modifiers.skillXP(skillId: action.skill.id);
 
+  // nonCombatSkillXP: percentage XP bonus for all non-combat skills.
+  if (!action.skill.isCombatSkill) {
+    xpModifier += modifiers.nonCombatSkillXP;
+  }
+
+  // altMagicSkillXP: percentage XP bonus for alt magic specifically.
+  if (action.skill == Skill.altMagic) {
+    xpModifier += modifiers.altMagicSkillXP;
+  }
+
   // Apply bonfire XP bonus for firemaking actions
   if (action.skill == Skill.firemaking && state.bonfire.isActive) {
     xpModifier += state.bonfire.xpBonus;
@@ -669,11 +679,21 @@ bool rollAndCollectDrops(
   final masteryTokenDrop = registries.drops.masteryTokenForSkill(action.skill);
   if (masteryTokenDrop != null) {
     final unlockedActions = builder.state.unlockedActionsCount(action.skill);
-    final tokenStack = masteryTokenDrop.rollWithContext(
+    var tokenStack = masteryTokenDrop.rollWithContext(
       registries.items,
       random,
       unlockedActions: unlockedActions,
     );
+
+    // flatMasteryTokens: flat bonus tokens added when a token drops.
+    final flatBonus = modifiers.flatMasteryTokens;
+    if (tokenStack != null && flatBonus > 0) {
+      tokenStack = ItemStack(
+        tokenStack.item,
+        count: tokenStack.count + flatBonus,
+      );
+    }
+
     if (tokenStack != null) {
       final success = builder.addInventory(tokenStack);
       if (!success) {
@@ -1446,12 +1466,26 @@ ForegroundResult _restartOrStop(
     );
     final hasAutoLooting = combatModifiers.autoLooting > 0;
 
+    // combatLootDoublingChance: percentage chance to double combat loot.
+    final combatDoublingChance =
+        combatModifiers.combatLootDoublingChance / 100.0;
+
+    // Helper to apply combat loot doubling to an item stack.
+    ItemStack applyLootDoubling(ItemStack stack) {
+      if (combatDoublingChance > 0 &&
+          random.nextDouble() < combatDoublingChance) {
+        return ItemStack(stack.item, count: stack.count * 2);
+      }
+      return stack;
+    }
+
     // Drop bones if the monster has them (bones stack in loot).
     // In dungeons, bones only drop when the dungeon's dropBones flag is true.
     final bones = action.bones;
     if (bones != null && (dungeon?.dropBones ?? true)) {
       final item = builder.registries.items.byId(bones.itemId);
-      final stack = ItemStack(item, count: bones.quantity);
+      var stack = ItemStack(item, count: bones.quantity);
+      stack = applyLootDoubling(stack);
       if (hasAutoLooting) {
         if (!builder.tryAddToInventory(stack)) {
           builder.addToLoot(stack, isBones: true);
@@ -1466,8 +1500,9 @@ ForegroundResult _restartOrStop(
     if (!isDungeon) {
       final lootTable = action.lootTable;
       if (lootTable != null) {
-        final loot = lootTable.roll(builder.registries.items, random);
+        var loot = lootTable.roll(builder.registries.items, random);
         if (loot != null) {
+          loot = applyLootDoubling(loot);
           if (hasAutoLooting) {
             if (!builder.tryAddToInventory(loot)) {
               builder.addToLoot(loot, isBones: false);

--- a/logic/lib/src/data/actions.dart
+++ b/logic/lib/src/data/actions.dart
@@ -338,16 +338,22 @@ class SkillAction extends Action {
 
   /// Returns the item doubling probability (0.0-1.0) for this action.
   ///
-  /// Queries the skillItemDoublingChance modifier with the action's skill,
-  /// action ID, and category, then converts from percentage to probability.
+  /// Combines skillItemDoublingChance (skill-scoped), globalItemDoublingChance
+  /// (unscoped), and doubleItemsSkill (skill/action/category-scoped).
+  /// All three are percentage points that stack additively.
   double doublingChance(ModifierAccessors modifiers) {
-    return (modifiers.skillItemDoublingChance(
-              skillId: skill.id,
-              actionId: id.localId,
-              categoryId: categoryId,
-            ) /
-            100.0)
-        .clamp(0.0, 1.0);
+    final skillChance = modifiers.skillItemDoublingChance(
+      skillId: skill.id,
+      actionId: id.localId,
+      categoryId: categoryId,
+    );
+    final globalChance = modifiers.globalItemDoublingChance;
+    final doubleItems = modifiers.doubleItemsSkill(
+      skillId: skill.id,
+      actionId: id.localId,
+      categoryId: categoryId,
+    );
+    return ((skillChance + globalChance + doubleItems) / 100.0).clamp(0.0, 1.0);
   }
 }
 

--- a/logic/test/global_modifiers_test.dart
+++ b/logic/test/global_modifiers_test.dart
@@ -1,0 +1,271 @@
+import 'dart:math';
+
+import 'package:logic/logic.dart';
+import 'package:test/test.dart';
+
+import 'test_helper.dart';
+
+void main() {
+  late WoodcuttingTree normalTree;
+
+  setUpAll(() async {
+    await loadTestRegistries();
+
+    normalTree =
+        testRegistries.woodcuttingAction('Normal Tree') as WoodcuttingTree;
+  });
+
+  group('globalItemDoublingChance', () {
+    test('stacks with skillItemDoublingChance', () {
+      const normalLogsId = MelvorId('melvorD:Normal_Logs');
+
+      // 50% from skill + 50% from global = 100% effective doubling.
+      final modifiers = StubModifierProvider({
+        'skillItemDoublingChance': 50,
+        'globalItemDoublingChance': 50,
+      });
+
+      final state = GlobalState.test(testRegistries);
+      final builder = StateUpdateBuilder(state);
+      final random = Random(42);
+
+      rollAndCollectDrops(
+        builder,
+        normalTree,
+        modifiers,
+        random,
+        const NoSelectedRecipe(),
+      );
+
+      // With 100% combined chance, should always double.
+      final count = builder.state.inventory.countById(normalLogsId);
+      expect(count, 2, reason: 'Should always double with 100% combined');
+    });
+
+    test('works alone without skillItemDoublingChance', () {
+      const normalLogsId = MelvorId('melvorD:Normal_Logs');
+
+      // 100% from global alone.
+      final modifiers = StubModifierProvider({'globalItemDoublingChance': 100});
+
+      final state = GlobalState.test(testRegistries);
+      final builder = StateUpdateBuilder(state);
+      final random = Random(42);
+
+      rollAndCollectDrops(
+        builder,
+        normalTree,
+        modifiers,
+        random,
+        const NoSelectedRecipe(),
+      );
+
+      final count = builder.state.inventory.countById(normalLogsId);
+      expect(count, 2, reason: 'Should double with 100% global chance');
+    });
+  });
+
+  group('doubleItemsSkill', () {
+    test('adds to doubling chance for matching skill', () {
+      const normalLogsId = MelvorId('melvorD:Normal_Logs');
+
+      // 100% from doubleItemsSkill alone should always double.
+      final modifiers = StubModifierProvider({'doubleItemsSkill': 100});
+
+      final state = GlobalState.test(testRegistries);
+      final builder = StateUpdateBuilder(state);
+      final random = Random(42);
+
+      rollAndCollectDrops(
+        builder,
+        normalTree,
+        modifiers,
+        random,
+        const NoSelectedRecipe(),
+      );
+
+      final count = builder.state.inventory.countById(normalLogsId);
+      expect(count, 2, reason: 'Should double with 100% doubleItemsSkill');
+    });
+  });
+
+  group('nonCombatSkillXP', () {
+    test('applies XP bonus to non-combat skills', () {
+      final state = GlobalState.test(testRegistries);
+
+      // +50% XP bonus for non-combat skills
+      final modifiers = StubModifierProvider({'nonCombatSkillXP': 50});
+      final base = xpPerAction(state, normalTree, StubModifierProvider());
+
+      final boosted = xpPerAction(state, normalTree, modifiers);
+
+      // 50% increase: boosted should be ~1.5x base.
+      expect(boosted.xp, greaterThan(base.xp));
+      expect(boosted.xp, (base.xp * 1.5).round());
+    });
+
+    test('stacks with skillXP modifier', () {
+      final state = GlobalState.test(testRegistries);
+
+      // +20% from skillXP and +30% from nonCombatSkillXP = +50% total.
+      final stacked = StubModifierProvider({
+        'skillXP': 20,
+        'nonCombatSkillXP': 30,
+      });
+      final separate50 = StubModifierProvider({'skillXP': 50});
+
+      final stackedXp = xpPerAction(state, normalTree, stacked);
+      final separate50Xp = xpPerAction(state, normalTree, separate50);
+
+      expect(stackedXp.xp, separate50Xp.xp);
+    });
+  });
+
+  group('altMagicSkillXP', () {
+    test('applies XP bonus to alt magic actions', () {
+      final altMagicActions = testRegistries.altMagic.actions;
+      if (altMagicActions.isEmpty) {
+        // Skip if no alt magic actions in test data.
+        return;
+      }
+      final altAction = altMagicActions.first;
+      final state = GlobalState.test(testRegistries);
+
+      final base = xpPerAction(state, altAction, StubModifierProvider());
+      final boosted = xpPerAction(
+        state,
+        altAction,
+        StubModifierProvider({'altMagicSkillXP': 100}),
+      );
+
+      // +100% XP: boosted should be 2x base.
+      expect(boosted.xp, base.xp * 2);
+    });
+
+    test('does not apply to non-alt-magic skills', () {
+      final state = GlobalState.test(testRegistries);
+
+      final base = xpPerAction(state, normalTree, StubModifierProvider());
+      final withAltMagicMod = xpPerAction(
+        state,
+        normalTree,
+        StubModifierProvider({'altMagicSkillXP': 100}),
+      );
+
+      // Alt magic XP mod should not affect woodcutting.
+      expect(withAltMagicMod.xp, base.xp);
+    });
+  });
+
+  group('flatMasteryTokens', () {
+    test('MasteryTokenDrop rollWithContext returns 1 token normally', () {
+      const drop = MasteryTokenDrop(skill: Skill.woodcutting);
+      // With 18500 unlocked, chance is 100%.
+      final result = drop.rollWithContext(
+        testItems,
+        Random(42),
+        unlockedActions: 18500,
+      );
+      expect(result, isNotNull);
+      expect(result!.count, 1);
+    });
+
+    test('flatMasteryTokens bonus is applied in rollAndCollectDrops', () {
+      const wcTokenId = MelvorId('melvorD:Mastery_Token_Woodcutting');
+
+      final modifiers = StubModifierProvider({'flatMasteryTokens': 2});
+
+      // Give max WC level so all actions unlocked for higher drop rate.
+      // Use a targeted approach: find a seed that drops a token first.
+      final state = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.woodcutting: SkillState(xp: 13034431, masteryPoolXp: 0),
+        },
+      );
+
+      // First find a seed that produces a token drop.
+      late int goodSeed;
+      var found = false;
+      for (var i = 0; i < 50000; i++) {
+        final builder = StateUpdateBuilder(state);
+        rollAndCollectDrops(
+          builder,
+          normalTree,
+          StubModifierProvider(),
+          Random(i),
+          const NoSelectedRecipe(),
+        );
+        if (builder.state.inventory.countById(wcTokenId) > 0) {
+          goodSeed = i;
+          found = true;
+          break;
+        }
+      }
+
+      expect(found, isTrue, reason: 'Should find a seed that drops a token');
+
+      // Now use the same seed with flatMasteryTokens modifier.
+      final builder = StateUpdateBuilder(state);
+      rollAndCollectDrops(
+        builder,
+        normalTree,
+        modifiers,
+        Random(goodSeed),
+        const NoSelectedRecipe(),
+      );
+      final count = builder.state.inventory.countById(wcTokenId);
+      expect(count, 3, reason: 'Token should be 1 base + 2 flat bonus');
+    });
+
+    test('does not add bonus when no token drops', () {
+      const wcTokenId = MelvorId('melvorD:Mastery_Token_Woodcutting');
+
+      final modifiers = StubModifierProvider({'flatMasteryTokens': 5});
+
+      // At level 1, drop rate is ~1/18500, so most trials produce no token.
+      final state = GlobalState.test(testRegistries);
+      final builder = StateUpdateBuilder(state);
+      rollAndCollectDrops(
+        builder,
+        normalTree,
+        modifiers,
+        Random(42),
+        const NoSelectedRecipe(),
+      );
+      final count = builder.state.inventory.countById(wcTokenId);
+      expect(count, 0, reason: 'No bonus without a token drop');
+    });
+  });
+
+  group('combatLootDoublingChance', () {
+    test('modifier accessor returns expected value', () {
+      final modifiers = StubModifierProvider({'combatLootDoublingChance': 100});
+      expect(modifiers.combatLootDoublingChance, 100);
+    });
+  });
+
+  group('doublingChance combines all sources', () {
+    test('SkillAction.doublingChance sums all three modifiers', () {
+      // 30% skill + 20% global + 10% doubleItemsSkill = 60% total.
+      final modifiers = StubModifierProvider({
+        'skillItemDoublingChance': 30,
+        'globalItemDoublingChance': 20,
+        'doubleItemsSkill': 10,
+      });
+
+      final chance = normalTree.doublingChance(modifiers);
+      expect(chance, closeTo(0.6, 0.001));
+    });
+
+    test('clamps to 1.0 when total exceeds 100%', () {
+      final modifiers = StubModifierProvider({
+        'skillItemDoublingChance': 80,
+        'globalItemDoublingChance': 80,
+      });
+
+      final chance = normalTree.doublingChance(modifiers);
+      expect(chance, 1.0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add consumption of 6 previously-unused modifiers: `globalItemDoublingChance`, `doubleItemsSkill`, `combatLootDoublingChance`, `nonCombatSkillXP`, `altMagicSkillXP`, and `flatMasteryTokens`
- `globalItemDoublingChance` and `doubleItemsSkill` stack additively with `skillItemDoublingChance` in `SkillAction.doublingChance`
- `combatLootDoublingChance` doubles combat bone and loot table drops via a local helper
- `nonCombatSkillXP` and `altMagicSkillXP` add percentage XP bonuses in `xpPerAction`
- `flatMasteryTokens` adds flat bonus tokens when a mastery token drops
- Filed #239 for `offItemChance` (needs off-item system) and #240 for `masteryPoolCap` (needs refactor to thread modifiers through `maxMasteryPoolXpForSkill`)

## Test plan

- [x] `globalItemDoublingChance` stacks with skill doubling (100% combined = always doubles)
- [x] `doubleItemsSkill` adds to doubling chance
- [x] `doublingChance` sums all three sources and clamps to 1.0
- [x] `nonCombatSkillXP` applies bonus and stacks with `skillXP`
- [x] `altMagicSkillXP` applies to alt magic but not other skills
- [x] `flatMasteryTokens` adds bonus tokens on drop, no effect when no drop
- [x] `combatLootDoublingChance` accessor verified
- [x] Full test suite passes (2359 tests)