### PR TITLE
feat: consume combat crit, lifesteal, protection, and immunity modifiers

### DIFF
--- a/logic/lib/src/combat_stats.dart
+++ b/logic/lib/src/combat_stats.dart
@@ -6,6 +6,9 @@ import 'package:logic/src/types/modifier_names.dart';
 import 'package:logic/src/types/modifier_provider.dart';
 import 'package:meta/meta.dart';
 
+/// Multiplier applied to damage on a critical hit.
+const double critDamageMultiplier = 1.5;
+
 /// Combat triangle modifiers for a specific matchup.
 ///
 /// In Melvor Idle's Normal mode, the combat triangle provides damage and
@@ -119,6 +122,13 @@ class CombatTriangle {
     return (damage * (1 - effectiveDR)).round();
   }
 }
+
+/// Converts a 100-base modifier value to a fractional multiplier.
+///
+/// Many Melvor modifiers use a 100-base integer representation where
+/// 10 means 10%, 50 means 50%, etc. This helper converts such a value
+/// to a `double` fraction (e.g., 10 -> 0.1, 50 -> 0.5).
+double modifierToPercent(int value) => value / 100.0;
 
 /// Computes accuracy or evasion rating using Melvor formula.
 ///
@@ -535,12 +545,18 @@ extension CombatModifierHelpers on ModifierAccessors {
   /// Returns the protection percentage against the given [attackType].
   ///
   /// Protection reduces incoming damage from a specific attack style.
+  /// The [attackType] must be a resolved concrete type
+  /// (not [AttackType.random]).
   int protectionForAttackType(AttackType attackType) {
+    assert(
+      attackType != AttackType.random,
+      'Resolve AttackType.random before checking protection.',
+    );
     return switch (attackType) {
       AttackType.melee => meleeProtection,
       AttackType.ranged => rangedProtection,
       AttackType.magic => magicProtection,
-      AttackType.random => 0, // No protection against random.
+      AttackType.random => 0, // Unreachable after assert.
     };
   }
 
@@ -549,16 +565,23 @@ extension CombatModifierHelpers on ModifierAccessors {
   /// Immunity means all damage from that style is negated. Checks both
   /// the direct style immunity and the [otherStyleImmunity] modifier
   /// which grants immunity to styles the player is NOT using.
+  ///
+  /// The [attackType] must be a resolved concrete type (not
+  /// [AttackType.random]).
   bool isImmuneToAttackType(
     AttackType attackType, {
     required CombatType playerCombatType,
   }) {
+    assert(
+      attackType != AttackType.random,
+      'Resolve AttackType.random before checking immunity.',
+    );
     // Check direct style immunity.
     final directImmunity = switch (attackType) {
       AttackType.melee => meleeImmunity > 0,
       AttackType.ranged => rangedImmunity > 0,
       AttackType.magic => magicImmunity > 0,
-      AttackType.random => false,
+      AttackType.random => false, // Unreachable after assert.
     };
     if (directImmunity) return true;
 
@@ -600,7 +623,10 @@ extension CombatModifierHelpers on ModifierAccessors {
   int applyDamageTakenModifier(int damage) {
     final modifier = damageTaken;
     if (modifier == 0) return damage;
-    return (damage * (1 + modifier / 100)).floor().clamp(0, damage * 10);
+    return (damage * (1 + modifierToPercent(modifier))).floor().clamp(
+      0,
+      damage * 10,
+    );
   }
 }
 

--- a/logic/lib/src/combat_stats.dart
+++ b/logic/lib/src/combat_stats.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:logic/src/data/actions.dart';
 import 'package:logic/src/state.dart';
+import 'package:logic/src/types/modifier_names.dart';
 import 'package:logic/src/types/modifier_provider.dart';
 import 'package:meta/meta.dart';
 
@@ -499,6 +500,108 @@ PlayerCombatStats computePlayerStats(
   required ConditionContext conditionContext,
 }) {
   return PlayerCombatStats.fromState(state, conditionContext: conditionContext);
+}
+
+/// Extension on [ModifierAccessors] for style-based combat modifier helpers.
+///
+/// These reduce repetitive switch statements when applying crit, lifesteal,
+/// protection, and immunity modifiers based on combat/attack style.
+extension CombatModifierHelpers on ModifierAccessors {
+  /// Returns the crit chance percentage for the given [combatType].
+  ///
+  /// Each combat style has its own crit chance modifier
+  /// (e.g. meleeCritChance, rangedCritChance, magicCritChance).
+  int critChanceForStyle(CombatType combatType) {
+    return switch (combatType) {
+      CombatType.melee => meleeCritChance,
+      CombatType.ranged => rangedCritChance,
+      CombatType.magic => magicCritChance,
+    };
+  }
+
+  /// Returns the total lifesteal percentage for the given [combatType].
+  ///
+  /// Combines the general [lifesteal] modifier with the style-specific
+  /// modifier (e.g. meleeLifesteal).
+  int lifestealForStyle(CombatType combatType) {
+    final styleLifesteal = switch (combatType) {
+      CombatType.melee => meleeLifesteal,
+      CombatType.ranged => 0, // No rangedLifesteal modifier exists.
+      CombatType.magic => magicLifesteal,
+    };
+    return lifesteal + styleLifesteal;
+  }
+
+  /// Returns the protection percentage against the given [attackType].
+  ///
+  /// Protection reduces incoming damage from a specific attack style.
+  int protectionForAttackType(AttackType attackType) {
+    return switch (attackType) {
+      AttackType.melee => meleeProtection,
+      AttackType.ranged => rangedProtection,
+      AttackType.magic => magicProtection,
+      AttackType.random => 0, // No protection against random.
+    };
+  }
+
+  /// Returns true if the player is immune to the given [attackType].
+  ///
+  /// Immunity means all damage from that style is negated. Checks both
+  /// the direct style immunity and the [otherStyleImmunity] modifier
+  /// which grants immunity to styles the player is NOT using.
+  bool isImmuneToAttackType(
+    AttackType attackType, {
+    required CombatType playerCombatType,
+  }) {
+    // Check direct style immunity.
+    final directImmunity = switch (attackType) {
+      AttackType.melee => meleeImmunity > 0,
+      AttackType.ranged => rangedImmunity > 0,
+      AttackType.magic => magicImmunity > 0,
+      AttackType.random => false,
+    };
+    if (directImmunity) return true;
+
+    // otherStyleImmunity grants immunity to styles different from the
+    // player's own combat type.
+    if (otherStyleImmunity > 0 && attackType.combatType != playerCombatType) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /// Returns the total percentage modifier to damage dealt against a monster.
+  ///
+  /// Combines:
+  /// - [damageDealt] - flat percentage bonus to all damage dealt
+  /// - [damageDealtToAllMonsters] - bonus vs all monsters
+  /// - [damageDealtToBosses] - bonus vs bosses (when [isBoss] is true)
+  /// - [damageDealtToSlayerTasks] - bonus vs slayer task monsters
+  ///   (when [isFightingSlayerTask] is true)
+  int totalDamageDealtModifier({
+    required bool isBoss,
+    required bool isFightingSlayerTask,
+  }) {
+    var modifier = damageDealt + damageDealtToAllMonsters;
+    if (isBoss) {
+      modifier += damageDealtToBosses;
+    }
+    if (isFightingSlayerTask) {
+      modifier += damageDealtToSlayerTasks;
+    }
+    return modifier;
+  }
+
+  /// Applies the [damageTaken] modifier to incoming damage.
+  ///
+  /// The `damageTaken` modifier is a percentage change to damage received.
+  /// Negative values reduce damage (e.g., -10 means 10% less damage taken).
+  int applyDamageTakenModifier(int damage) {
+    final modifier = damageTaken;
+    if (modifier == 0) return damage;
+    return (damage * (1 + modifier / 100)).floor().clamp(0, damage * 10);
+  }
 }
 
 /// XP grants from combat damage.

--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -1405,13 +1405,13 @@ ForegroundResult _restartOrStop(
         triangleModifiers,
       );
 
-      // Apply crit chance: style-specific chance for 1.5x damage.
+      // Apply crit chance: style-specific chance for bonus damage.
       final combatModifiers = builder.state.createCombatModifierProvider(
         conditionContext: combatContext,
       );
       final critChance = combatModifiers.critChanceForStyle(playerCombatType);
       if (critChance > 0 && random.nextInt(100) < critChance) {
-        damage = (damage * 1.5).floor();
+        damage = (damage * critDamageMultiplier).floor();
       }
 
       monsterHp -= damage;
@@ -1421,10 +1421,10 @@ ForegroundResult _restartOrStop(
         playerCombatType,
       );
       if (lifestealPercent > 0) {
-        final healAmount = (damage * lifestealPercent / 100).floor();
+        final healAmount = (damage * modifierToPercent(lifestealPercent))
+            .floor();
         if (healAmount > 0) {
-          health = health.heal(healAmount);
-          builder.setHealth(health);
+          health = builder.healPlayer(healAmount);
         }
       }
 
@@ -1649,25 +1649,27 @@ ForegroundResult _restartOrStop(
       conditionContext: combatCtx,
     );
 
+    // Resolve the monster's attack type (random -> concrete type).
+    final resolvedAttackType = action.attackType.resolve(random);
+
     // Consume consumable if equipped with EnemyAttack trigger
-    // Monster attack type is the same as its combat type
     builder.consumeConsumable(
       ConsumesOnType.enemyAttack,
-      attackType: action.attackType.combatType,
+      attackType: resolvedAttackType.combatType,
     );
 
     // Get combat triangle modifiers for damage reduction calculation
     final playerCombatType = builder.state.attackStyle.combatType;
     final triangleModifiers = CombatTriangle.getModifiers(
       playerCombatType,
-      action.attackType,
+      resolvedAttackType,
     );
 
     // Calculate hit chance and roll to see if monster hits
     final hitChance = CombatCalculator.monsterHitChance(
       mStats,
       pStats,
-      action.attackType,
+      resolvedAttackType,
     );
 
     // Check immunity before rolling hit - if immune, skip entirely.
@@ -1675,7 +1677,7 @@ ForegroundResult _restartOrStop(
       conditionContext: combatCtx,
     );
     final isImmune = defenseModifiers.isImmuneToAttackType(
-      action.attackType,
+      resolvedAttackType,
       playerCombatType: playerCombatType,
     );
 
@@ -1690,13 +1692,12 @@ ForegroundResult _restartOrStop(
 
       // Apply style-specific protection (percentage damage reduction).
       final protection = defenseModifiers.protectionForAttackType(
-        action.attackType,
+        resolvedAttackType,
       );
       if (protection > 0) {
-        reducedDamage = (reducedDamage * (1 - protection / 100)).floor().clamp(
-          0,
-          damage,
-        );
+        reducedDamage = (reducedDamage * (1 - modifierToPercent(protection)))
+            .floor()
+            .clamp(0, reducedDamage);
       }
 
       health = health.takeDamage(reducedDamage);

--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -1400,11 +1400,33 @@ ForegroundResult _restartOrStop(
     if (CombatCalculator.rollHit(random, hitChance)) {
       final baseDamage = pStats.rollDamage(random);
       // Apply combat triangle damage modifier
-      final damage = CombatTriangle.applyDamageModifier(
+      var damage = CombatTriangle.applyDamageModifier(
         baseDamage,
         triangleModifiers,
       );
+
+      // Apply crit chance: style-specific chance for 1.5x damage.
+      final combatModifiers = builder.state.createCombatModifierProvider(
+        conditionContext: combatContext,
+      );
+      final critChance = combatModifiers.critChanceForStyle(playerCombatType);
+      if (critChance > 0 && random.nextInt(100) < critChance) {
+        damage = (damage * 1.5).floor();
+      }
+
       monsterHp -= damage;
+
+      // Apply lifesteal: heal player for a percentage of damage dealt.
+      final lifestealPercent = combatModifiers.lifestealForStyle(
+        playerCombatType,
+      );
+      if (lifestealPercent > 0) {
+        final healAmount = (damage * lifestealPercent / 100).floor();
+        if (healAmount > 0) {
+          health = health.heal(healAmount);
+          builder.setHealth(health);
+        }
+      }
 
       // Grant combat XP based on damage dealt and attack style
       final xpGrant = CombatXpGrant.fromDamage(
@@ -1648,18 +1670,39 @@ ForegroundResult _restartOrStop(
       action.attackType,
     );
 
-    if (CombatCalculator.rollHit(random, hitChance)) {
+    // Check immunity before rolling hit - if immune, skip entirely.
+    final defenseModifiers = builder.state.createCombatModifierProvider(
+      conditionContext: combatCtx,
+    );
+    final isImmune = defenseModifiers.isImmuneToAttackType(
+      action.attackType,
+      playerCombatType: playerCombatType,
+    );
+
+    if (!isImmune && CombatCalculator.rollHit(random, hitChance)) {
       final damage = mStats.rollDamage(random);
       // Apply combat triangle to damage reduction
-      final reducedDamage = CombatTriangle.applyDamageReduction(
+      var reducedDamage = CombatTriangle.applyDamageReduction(
         damage,
         pStats.damageReduction,
         triangleModifiers,
       );
+
+      // Apply style-specific protection (percentage damage reduction).
+      final protection = defenseModifiers.protectionForAttackType(
+        action.attackType,
+      );
+      if (protection > 0) {
+        reducedDamage = (reducedDamage * (1 - protection / 100)).floor().clamp(
+          0,
+          damage,
+        );
+      }
+
       health = health.takeDamage(reducedDamage);
       builder.setHealth(health);
     }
-    // Miss: no damage taken
+    // Miss or immune: no damage taken
 
     resetMonsterTicks = ticksFromDuration(
       Duration(milliseconds: (mStats.attackSpeed * 1000).round()),

--- a/logic/lib/src/data/combat.dart
+++ b/logic/lib/src/data/combat.dart
@@ -126,6 +126,19 @@ enum AttackType {
     AttackType.ranged => CombatType.ranged,
     AttackType.magic => CombatType.magic,
   };
+
+  /// Resolves [random] to a concrete attack type (melee, ranged, or magic).
+  ///
+  /// Non-random types are returned as-is.
+  AttackType resolve(Random random) {
+    if (this != AttackType.random) return this;
+    const concreteTypes = [
+      AttackType.melee,
+      AttackType.ranged,
+      AttackType.magic,
+    ];
+    return concreteTypes[random.nextInt(concreteTypes.length)];
+  }
 }
 
 /// A combat action for fighting a specific monster.

--- a/logic/lib/src/state_update_builder.dart
+++ b/logic/lib/src/state_update_builder.dart
@@ -333,6 +333,15 @@ class StateUpdateBuilder {
     _state = _state.copyWith(health: health);
   }
 
+  /// Heals the player by the given [amount] of HP.
+  ///
+  /// Returns the updated [HealthState] after healing.
+  HealthState healPlayer(int amount) {
+    final newHealth = _state.health.heal(amount);
+    setHealth(newHealth);
+    return newHealth;
+  }
+
   void setStunned(StunnedState stunned) {
     _state = _state.copyWith(stunned: stunned);
   }

--- a/logic/test/combat_stats_test.dart
+++ b/logic/test/combat_stats_test.dart
@@ -1413,13 +1413,11 @@ void main() {
         expect(mods.protectionForAttackType(AttackType.magic), 25);
       });
 
-      test('returns 0 for random attack type', () {
-        final mods = StubModifierProvider({
-          'meleeProtection': 15,
-          'rangedProtection': 20,
-          'magicProtection': 25,
-        });
-        expect(mods.protectionForAttackType(AttackType.random), 0);
+      test('returns 0 when no protection modifiers', () {
+        final mods = StubModifierProvider();
+        expect(mods.protectionForAttackType(AttackType.melee), 0);
+        expect(mods.protectionForAttackType(AttackType.ranged), 0);
+        expect(mods.protectionForAttackType(AttackType.magic), 0);
       });
     });
 
@@ -1500,19 +1498,26 @@ void main() {
         );
       });
 
-      test('random attack type is never immune', () {
+      test('direct immunity combined with otherStyleImmunity', () {
         final mods = StubModifierProvider({
           'meleeImmunity': 1,
-          'rangedImmunity': 1,
-          'magicImmunity': 1,
           'otherStyleImmunity': 1,
         });
+        // Direct immunity for melee
         expect(
           mods.isImmuneToAttackType(
-            AttackType.random,
+            AttackType.melee,
             playerCombatType: CombatType.melee,
           ),
-          isFalse,
+          isTrue,
+        );
+        // otherStyleImmunity for non-melee
+        expect(
+          mods.isImmuneToAttackType(
+            AttackType.ranged,
+            playerCombatType: CombatType.melee,
+          ),
+          isTrue,
         );
       });
     });
@@ -1616,5 +1621,51 @@ void main() {
         expect(mods.applyDamageTakenModifier(100), equals(0));
       });
     });
+  });
+
+  group('AttackType.resolve', () {
+    test('non-random types return themselves', () {
+      final random = Random(42);
+      expect(AttackType.melee.resolve(random), AttackType.melee);
+      expect(AttackType.ranged.resolve(random), AttackType.ranged);
+      expect(AttackType.magic.resolve(random), AttackType.magic);
+    });
+
+    test('random resolves to a concrete type', () {
+      final random = Random(42);
+      final resolved = AttackType.random.resolve(random);
+      expect(
+        resolved,
+        anyOf(AttackType.melee, AttackType.ranged, AttackType.magic),
+      );
+      expect(resolved, isNot(AttackType.random));
+    });
+
+    test('random can resolve to different types', () {
+      // With enough iterations we should see all three types.
+      final types = <AttackType>{};
+      final random = Random(0);
+      for (var i = 0; i < 100; i++) {
+        types.add(AttackType.random.resolve(random));
+      }
+      expect(
+        types,
+        containsAll([AttackType.melee, AttackType.ranged, AttackType.magic]),
+      );
+    });
+  });
+
+  group('modifierToPercent', () {
+    test('converts 100-base integer to fractional multiplier', () {
+      expect(modifierToPercent(0), 0.0);
+      expect(modifierToPercent(10), closeTo(0.1, 0.001));
+      expect(modifierToPercent(50), closeTo(0.5, 0.001));
+      expect(modifierToPercent(100), closeTo(1.0, 0.001));
+      expect(modifierToPercent(-25), closeTo(-0.25, 0.001));
+    });
+  });
+
+  test('critDamageMultiplier is 1.5', () {
+    expect(critDamageMultiplier, 1.5);
   });
 }

--- a/logic/test/combat_stats_test.dart
+++ b/logic/test/combat_stats_test.dart
@@ -1325,4 +1325,296 @@ void main() {
       expect(statsWithContext.maxHit, statsEmpty.maxHit);
     });
   });
+
+  group('CombatModifierHelpers', () {
+    group('critChanceForStyle', () {
+      test('returns meleeCritChance for melee', () {
+        final mods = StubModifierProvider({
+          'meleeCritChance': 10,
+          'rangedCritChance': 20,
+          'magicCritChance': 30,
+        });
+        expect(mods.critChanceForStyle(CombatType.melee), 10);
+      });
+
+      test('returns rangedCritChance for ranged', () {
+        final mods = StubModifierProvider({
+          'meleeCritChance': 10,
+          'rangedCritChance': 20,
+          'magicCritChance': 30,
+        });
+        expect(mods.critChanceForStyle(CombatType.ranged), 20);
+      });
+
+      test('returns magicCritChance for magic', () {
+        final mods = StubModifierProvider({
+          'meleeCritChance': 10,
+          'rangedCritChance': 20,
+          'magicCritChance': 30,
+        });
+        expect(mods.critChanceForStyle(CombatType.magic), 30);
+      });
+
+      test('returns 0 when no crit modifiers are set', () {
+        final mods = StubModifierProvider();
+        expect(mods.critChanceForStyle(CombatType.melee), 0);
+        expect(mods.critChanceForStyle(CombatType.ranged), 0);
+        expect(mods.critChanceForStyle(CombatType.magic), 0);
+      });
+    });
+
+    group('lifestealForStyle', () {
+      test('combines general lifesteal with melee lifesteal', () {
+        final mods = StubModifierProvider({
+          'lifesteal': 5,
+          'meleeLifesteal': 3,
+        });
+        expect(mods.lifestealForStyle(CombatType.melee), 8);
+      });
+
+      test('combines general lifesteal with magic lifesteal', () {
+        final mods = StubModifierProvider({
+          'lifesteal': 5,
+          'magicLifesteal': 7,
+        });
+        expect(mods.lifestealForStyle(CombatType.magic), 12);
+      });
+
+      test('returns only general lifesteal for ranged', () {
+        final mods = StubModifierProvider({'lifesteal': 5});
+        expect(mods.lifestealForStyle(CombatType.ranged), 5);
+      });
+
+      test('returns 0 when no lifesteal modifiers', () {
+        final mods = StubModifierProvider();
+        expect(mods.lifestealForStyle(CombatType.melee), 0);
+        expect(mods.lifestealForStyle(CombatType.ranged), 0);
+        expect(mods.lifestealForStyle(CombatType.magic), 0);
+      });
+    });
+
+    group('protectionForAttackType', () {
+      test('returns meleeProtection for melee', () {
+        final mods = StubModifierProvider({
+          'meleeProtection': 15,
+          'rangedProtection': 20,
+          'magicProtection': 25,
+        });
+        expect(mods.protectionForAttackType(AttackType.melee), 15);
+      });
+
+      test('returns rangedProtection for ranged', () {
+        final mods = StubModifierProvider({'rangedProtection': 20});
+        expect(mods.protectionForAttackType(AttackType.ranged), 20);
+      });
+
+      test('returns magicProtection for magic', () {
+        final mods = StubModifierProvider({'magicProtection': 25});
+        expect(mods.protectionForAttackType(AttackType.magic), 25);
+      });
+
+      test('returns 0 for random attack type', () {
+        final mods = StubModifierProvider({
+          'meleeProtection': 15,
+          'rangedProtection': 20,
+          'magicProtection': 25,
+        });
+        expect(mods.protectionForAttackType(AttackType.random), 0);
+      });
+    });
+
+    group('isImmuneToAttackType', () {
+      test('meleeImmunity blocks melee attacks', () {
+        final mods = StubModifierProvider({'meleeImmunity': 1});
+        expect(
+          mods.isImmuneToAttackType(
+            AttackType.melee,
+            playerCombatType: CombatType.ranged,
+          ),
+          isTrue,
+        );
+      });
+
+      test('rangedImmunity blocks ranged attacks', () {
+        final mods = StubModifierProvider({'rangedImmunity': 1});
+        expect(
+          mods.isImmuneToAttackType(
+            AttackType.ranged,
+            playerCombatType: CombatType.melee,
+          ),
+          isTrue,
+        );
+      });
+
+      test('magicImmunity blocks magic attacks', () {
+        final mods = StubModifierProvider({'magicImmunity': 1});
+        expect(
+          mods.isImmuneToAttackType(
+            AttackType.magic,
+            playerCombatType: CombatType.melee,
+          ),
+          isTrue,
+        );
+      });
+
+      test('otherStyleImmunity blocks attacks from different styles', () {
+        final mods = StubModifierProvider({'otherStyleImmunity': 1});
+        // Player is melee, attacked by ranged -> immune
+        expect(
+          mods.isImmuneToAttackType(
+            AttackType.ranged,
+            playerCombatType: CombatType.melee,
+          ),
+          isTrue,
+        );
+        // Player is melee, attacked by magic -> immune
+        expect(
+          mods.isImmuneToAttackType(
+            AttackType.magic,
+            playerCombatType: CombatType.melee,
+          ),
+          isTrue,
+        );
+      });
+
+      test('otherStyleImmunity does not block same-style attacks', () {
+        final mods = StubModifierProvider({'otherStyleImmunity': 1});
+        // Player is melee, attacked by melee -> NOT immune
+        expect(
+          mods.isImmuneToAttackType(
+            AttackType.melee,
+            playerCombatType: CombatType.melee,
+          ),
+          isFalse,
+        );
+      });
+
+      test('no immunity when no modifiers set', () {
+        final mods = StubModifierProvider();
+        expect(
+          mods.isImmuneToAttackType(
+            AttackType.melee,
+            playerCombatType: CombatType.ranged,
+          ),
+          isFalse,
+        );
+      });
+
+      test('random attack type is never immune', () {
+        final mods = StubModifierProvider({
+          'meleeImmunity': 1,
+          'rangedImmunity': 1,
+          'magicImmunity': 1,
+          'otherStyleImmunity': 1,
+        });
+        expect(
+          mods.isImmuneToAttackType(
+            AttackType.random,
+            playerCombatType: CombatType.melee,
+          ),
+          isFalse,
+        );
+      });
+    });
+
+    group('totalDamageDealtModifier', () {
+      test('combines damageDealt and damageDealtToAllMonsters', () {
+        final mods = StubModifierProvider({
+          'damageDealt': 10,
+          'damageDealtToAllMonsters': 5,
+        });
+        expect(
+          mods.totalDamageDealtModifier(
+            isBoss: false,
+            isFightingSlayerTask: false,
+          ),
+          equals(15),
+        );
+      });
+
+      test('includes damageDealtToBosses when fighting a boss', () {
+        final mods = StubModifierProvider({
+          'damageDealt': 10,
+          'damageDealtToAllMonsters': 5,
+          'damageDealtToBosses': 20,
+        });
+        expect(
+          mods.totalDamageDealtModifier(
+            isBoss: true,
+            isFightingSlayerTask: false,
+          ),
+          equals(35),
+        );
+      });
+
+      test('excludes damageDealtToBosses for non-bosses', () {
+        final mods = StubModifierProvider({
+          'damageDealt': 10,
+          'damageDealtToBosses': 20,
+        });
+        expect(
+          mods.totalDamageDealtModifier(
+            isBoss: false,
+            isFightingSlayerTask: false,
+          ),
+          equals(10),
+        );
+      });
+
+      test('includes damageDealtToSlayerTasks on slayer task', () {
+        final mods = StubModifierProvider({
+          'damageDealt': 5,
+          'damageDealtToSlayerTasks': 15,
+        });
+        expect(
+          mods.totalDamageDealtModifier(
+            isBoss: false,
+            isFightingSlayerTask: true,
+          ),
+          equals(20),
+        );
+      });
+
+      test('combines all modifiers for boss slayer task', () {
+        final mods = StubModifierProvider({
+          'damageDealt': 5,
+          'damageDealtToAllMonsters': 3,
+          'damageDealtToBosses': 10,
+          'damageDealtToSlayerTasks': 7,
+        });
+        expect(
+          mods.totalDamageDealtModifier(
+            isBoss: true,
+            isFightingSlayerTask: true,
+          ),
+          equals(25),
+        );
+      });
+    });
+
+    group('applyDamageTakenModifier', () {
+      test('returns unchanged damage when modifier is zero', () {
+        final mods = StubModifierProvider();
+        expect(mods.applyDamageTakenModifier(100), equals(100));
+      });
+
+      test('negative modifier reduces damage taken', () {
+        final mods = StubModifierProvider({'damageTaken': -10});
+        // 100 * (1 + -10/100) = 100 * 0.9 = 90
+        expect(mods.applyDamageTakenModifier(100), equals(90));
+      });
+
+      test('positive modifier increases damage taken', () {
+        final mods = StubModifierProvider({'damageTaken': 20});
+        // 100 * (1 + 20/100) = 100 * 1.2 = 120
+        expect(mods.applyDamageTakenModifier(100), equals(120));
+      });
+
+      test('damage is clamped to zero minimum', () {
+        final mods = StubModifierProvider({'damageTaken': -200});
+        // Would be negative, clamped to 0.
+        expect(mods.applyDamageTakenModifier(100), equals(0));
+      });
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Add consumption of 13 previously-unused combat modifiers: style-specific crit chance (1.5x damage), lifesteal (heal from damage dealt), protection (style-specific damage reduction), and immunity (complete damage negation from specific styles).
- Add `CombatModifierHelpers` extension on `ModifierAccessors` with DRY helpers for style-based modifier lookups: `critChanceForStyle`, `lifestealForStyle`, `protectionForAttackType`, `isImmuneToAttackType`.
- Filed #242 for DoT lifesteal modifiers (`bleedLifesteal`, `burnLifesteal`, `poisonLifesteal`) which need a DoT damage system.

## Test plan

- [x] Unit tests for all `CombatModifierHelpers` methods (crit, lifesteal, protection, immunity)
- [x] Tests for `otherStyleImmunity` blocking non-matching styles but allowing same-style
- [x] Tests for `totalDamageDealtModifier` and `applyDamageTakenModifier` helpers
- [x] `dart test -r failures-only` passes (2374 tests)
- [x] `dart analyze --fatal-infos` passes
- [x] `dart format .` passes