### PR TITLE
feat: consume combat misc and resistance modifiers

### DIFF
--- a/logic/lib/src/combat_stats.dart
+++ b/logic/lib/src/combat_stats.dart
@@ -144,7 +144,12 @@ int _computeBaseMaxHit({required int effectiveLevel, required int bonus}) {
 /// Uses Melvor-style formulas to calculate max hit, accuracy, evasion, etc.
 @immutable
 class PlayerCombatStats extends Stats {
-  const PlayerCombatStats._({
+  /// Creates player combat stats with all fields.
+  ///
+  /// Use [PlayerCombatStats.fromState] for production code.
+  /// This constructor is visible for testing direct stat construction.
+  @visibleForTesting
+  const PlayerCombatStats({
     required super.minHit,
     required super.maxHit,
     required super.damageReduction,
@@ -153,6 +158,11 @@ class PlayerCombatStats extends Stats {
     required this.meleeEvasion,
     required this.rangedEvasion,
     required this.magicEvasion,
+    this.flatResistanceAgainstMelee = 0,
+    this.flatResistanceAgainstRanged = 0,
+    this.flatResistanceAgainstMagic = 0,
+    this.flatResistanceAgainstSlayerTasks = 0,
+    this.isFightingSlayerTask = false,
   });
 
   /// Computes player stats from current game state.
@@ -338,7 +348,7 @@ class PlayerCombatStats extends Stats {
       modifier: bonuses.magicEvasion,
     );
 
-    return PlayerCombatStats._(
+    return PlayerCombatStats(
       minHit: minHit,
       maxHit: maxHit,
       damageReduction: damageReduction,
@@ -347,6 +357,12 @@ class PlayerCombatStats extends Stats {
       meleeEvasion: meleeEvasion,
       rangedEvasion: rangedEvasion,
       magicEvasion: magicEvasion,
+      flatResistanceAgainstMelee: bonuses.flatResistanceAgainstMelee,
+      flatResistanceAgainstRanged: bonuses.flatResistanceAgainstRanged,
+      flatResistanceAgainstMagic: bonuses.flatResistanceAgainstMagic,
+      flatResistanceAgainstSlayerTasks:
+          bonuses.flatResistanceAgainstSlayerTasks,
+      isFightingSlayerTask: conditionContext.isFightingSlayerTask,
     );
   }
 
@@ -362,6 +378,21 @@ class PlayerCombatStats extends Stats {
   /// Player's magic evasion rating.
   final int magicEvasion;
 
+  /// Flat resistance bonus against melee attacks (in resistance points).
+  final int flatResistanceAgainstMelee;
+
+  /// Flat resistance bonus against ranged attacks (in resistance points).
+  final int flatResistanceAgainstRanged;
+
+  /// Flat resistance bonus against magic attacks (in resistance points).
+  final int flatResistanceAgainstMagic;
+
+  /// Flat resistance bonus when fighting a slayer task (in resistance points).
+  final int flatResistanceAgainstSlayerTasks;
+
+  /// Whether the player is currently fighting their slayer task monster.
+  final bool isFightingSlayerTask;
+
   /// Gets the evasion rating for a specific attack type.
   int evasionForAttackType(AttackType attackType) {
     return switch (attackType) {
@@ -370,6 +401,25 @@ class PlayerCombatStats extends Stats {
       AttackType.magic => magicEvasion,
       AttackType.random => meleeEvasion, // Default to melee for random
     };
+  }
+
+  /// Computes effective damage reduction against a specific attack type.
+  ///
+  /// Adds attack-type-specific and slayer-task-specific flat resistance
+  /// bonuses on top of the base damage reduction. Each resistance point
+  /// is 1% DR. The result is clamped to [0.0, 0.95].
+  double damageReductionAgainst(AttackType attackType) {
+    var extraResistance = switch (attackType) {
+      AttackType.melee => flatResistanceAgainstMelee,
+      AttackType.ranged => flatResistanceAgainstRanged,
+      AttackType.magic => flatResistanceAgainstMagic,
+      AttackType.random => 0,
+    };
+    if (isFightingSlayerTask) {
+      extraResistance += flatResistanceAgainstSlayerTasks;
+    }
+    if (extraResistance == 0) return damageReduction;
+    return (damageReduction + extraResistance / 100).clamp(0.0, 0.95);
   }
 }
 

--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -1364,6 +1364,9 @@ ForegroundResult _restartOrStop(
       conditionContext: combatContext,
     );
     final mStats = MonsterCombatStats.fromAction(action);
+    final combatModifiers = builder.state.createCombatModifierProvider(
+      conditionContext: combatContext,
+    );
 
     // Consume summoning tablet charges (1 per attack, for relevant familiars)
     builder.consumeSummonChargesForCombat(
@@ -1378,44 +1381,58 @@ ForegroundResult _restartOrStop(
       attackType: playerCombatType,
     );
 
-    // Get combat triangle modifiers based on player vs monster combat types
-    final triangleModifiers = CombatTriangle.getModifiers(
-      playerCombatType,
-      action.attackType,
-    );
-
-    // Calculate hit chance and roll to see if attack hits
-    // Player attacks monster using the player's combat type for evasion lookup
-    final monsterDefenceType = playerCombatType == CombatType.melee
-        ? AttackType.melee
-        : playerCombatType == CombatType.ranged
-        ? AttackType.ranged
-        : AttackType.magic;
-    final hitChance = CombatCalculator.playerHitChance(
-      pStats,
-      mStats,
-      monsterDefenceType,
-    );
-
-    if (CombatCalculator.rollHit(random, hitChance)) {
-      final baseDamage = pStats.rollDamage(random);
-      // Apply combat triangle damage modifier
-      final damage = CombatTriangle.applyDamageModifier(
-        baseDamage,
-        triangleModifiers,
+    // cantAttack modifier: skip the attack entirely (no hit roll, no damage)
+    if (combatModifiers.cantAttack <= 0) {
+      // Get combat triangle modifiers based on player vs monster combat types
+      final triangleModifiers = CombatTriangle.getModifiers(
+        playerCombatType,
+        action.attackType,
       );
-      monsterHp -= damage;
 
-      // Grant combat XP based on damage dealt and attack style
-      final xpGrant = CombatXpGrant.fromDamage(
-        damage,
-        builder.state.attackStyle,
+      // Calculate hit chance and roll to see if attack hits
+      // Player attacks monster using the player's combat type for evasion
+      final monsterDefenceType = playerCombatType == CombatType.melee
+          ? AttackType.melee
+          : playerCombatType == CombatType.ranged
+          ? AttackType.ranged
+          : AttackType.magic;
+      final hitChance = CombatCalculator.playerHitChance(
+        pStats,
+        mStats,
+        monsterDefenceType,
       );
-      for (final entry in xpGrant.xpGrants.entries) {
-        builder.addSkillXp(entry.key, entry.value);
+
+      // attackRolls: number of additional attack rolls per turn.
+      // Each extra roll is an independent chance to hit.
+      final extraRolls = combatModifiers.attackRolls;
+      final totalRolls = 1 + extraRolls;
+
+      for (var roll = 0; roll < totalRolls; roll++) {
+        if (CombatCalculator.rollHit(random, hitChance)) {
+          // disableAttackDamage: attack hits but deals 0 damage.
+          // XP is still not granted since no damage is dealt.
+          if (combatModifiers.disableAttackDamage > 0) continue;
+
+          final baseDamage = pStats.rollDamage(random);
+          // Apply combat triangle damage modifier
+          final damage = CombatTriangle.applyDamageModifier(
+            baseDamage,
+            triangleModifiers,
+          );
+          monsterHp -= damage;
+
+          // Grant combat XP based on damage dealt and attack style
+          final xpGrant = CombatXpGrant.fromDamage(
+            damage,
+            builder.state.attackStyle,
+          );
+          for (final entry in xpGrant.xpGrants.entries) {
+            builder.addSkillXp(entry.key, entry.value);
+          }
+        }
+        // Miss: no damage dealt, no XP granted
       }
     }
-    // Miss: no damage dealt, no XP granted
 
     resetPlayerTicks = ticksFromDuration(
       Duration(milliseconds: (pStats.attackSpeed * 1000).round()),
@@ -1626,6 +1643,9 @@ ForegroundResult _restartOrStop(
       builder.state,
       conditionContext: combatCtx,
     );
+    final defenceModifiers = builder.state.createCombatModifierProvider(
+      conditionContext: combatCtx,
+    );
 
     // Consume consumable if equipped with EnemyAttack trigger
     // Monster attack type is the same as its combat type
@@ -1641,23 +1661,46 @@ ForegroundResult _restartOrStop(
       action.attackType,
     );
 
-    // Calculate hit chance and roll to see if monster hits
-    final hitChance = CombatCalculator.monsterHitChance(
-      mStats,
-      pStats,
-      action.attackType,
-    );
+    // Calculate hit chance and roll to see if monster hits.
+    // cantEvade: player cannot evade, so hit chance is always 100%.
+    final hitChance = defenceModifiers.cantEvade > 0
+        ? 1.0
+        : CombatCalculator.monsterHitChance(mStats, pStats, action.attackType);
 
     if (CombatCalculator.rollHit(random, hitChance)) {
       final damage = mStats.rollDamage(random);
-      // Apply combat triangle to damage reduction
+      // Use type-specific damage reduction (includes flatResistanceAgainst*
+      // and flatResistanceAgainstSlayerTasks modifiers).
+      final effectiveDR = pStats.damageReductionAgainst(action.attackType);
       final reducedDamage = CombatTriangle.applyDamageReduction(
         damage,
-        pStats.damageReduction,
+        effectiveDR,
         triangleModifiers,
       );
       health = health.takeDamage(reducedDamage);
       builder.setHealth(health);
+
+      // Reflect damage back to the monster when hit.
+      // reflectDamage: percentage of damage taken reflected.
+      // rolledReflectDamage: random value from 0 to (% of player max hit).
+      // flatReflectDamage: flat damage reflected per hit.
+      final reflectPercent = defenceModifiers.reflectDamage;
+      final rolledReflectPercent = defenceModifiers.rolledReflectDamage;
+      final flatReflect = defenceModifiers.flatReflectDamage;
+      var totalReflect = 0;
+      if (reflectPercent > 0) {
+        totalReflect += (reducedDamage * reflectPercent / 100).floor();
+      }
+      if (rolledReflectPercent > 0) {
+        final maxReflect = (pStats.maxHit * rolledReflectPercent / 100).floor();
+        if (maxReflect > 0) {
+          totalReflect += random.nextInt(maxReflect) + 1;
+        }
+      }
+      totalReflect += flatReflect;
+      if (totalReflect > 0) {
+        monsterHp -= totalReflect;
+      }
     }
     // Miss: no damage taken
 

--- a/logic/lib/src/data/items.dart
+++ b/logic/lib/src/data/items.dart
@@ -290,6 +290,7 @@ class Item {
     this.potionAction,
     this.consumesOn = const [],
     this.dropTable,
+    this.modifiers = const ModifierDataSet([]),
   }) : id = MelvorId('melvorD:${name.replaceAll(' ', '_')}'),
        itemType = potionCharges != null ? 'Potion' : 'Item',
        sellsFor = gp,
@@ -298,7 +299,6 @@ class Item {
        description = null,
        media = null,
        validSlots = const <EquipmentSlot>[],
-       modifiers = const ModifierDataSet([]),
        conditionalModifiers = const <ConditionalModifier>[],
        equipmentStats = EquipmentStats.empty,
        masteryTokenSkillId = null;

--- a/logic/test/combat_modifiers_test.dart
+++ b/logic/test/combat_modifiers_test.dart
@@ -1,0 +1,318 @@
+import 'dart:math';
+
+import 'package:logic/logic.dart';
+import 'package:test/test.dart';
+
+import 'test_helper.dart';
+
+/// Helper to create a test item with a single modifier.
+Item _itemWithModifier(String name, String modifierName, num value) {
+  return Item.test(
+    name,
+    gp: 0,
+    modifiers: ModifierDataSet([
+      ModifierData(
+        name: modifierName,
+        entries: [ModifierEntry(value: value)],
+      ),
+    ]),
+  );
+}
+
+/// Runs combat ticks and returns the updated state.
+/// Uses a fixed seed for deterministic results.
+GlobalState _runCombatTicks(GlobalState state, int ticks, {int seed = 42}) {
+  final random = Random(seed);
+  final builder = StateUpdateBuilder(state);
+  consumeTicks(builder, ticks, random: random);
+  return builder.build();
+}
+
+/// Starts combat against the given monster and returns the state.
+GlobalState _startCombat(GlobalState state, CombatAction monster) {
+  return state.startAction(monster, random: Random(0));
+}
+
+void main() {
+  setUpAll(loadTestRegistries);
+
+  late CombatAction plantMonster;
+
+  setUp(() {
+    plantMonster = testRegistries.combatAction('Plant');
+  });
+
+  group('cantAttack modifier', () {
+    test('player deals no damage when cantAttack is active', () {
+      final cantAttackItem = _itemWithModifier(
+        'CantAttackRing',
+        'cantAttack',
+        1,
+      );
+      final equipment = Equipment(
+        foodSlots: const [null, null, null],
+        selectedFoodSlot: 0,
+        gearSlots: {EquipmentSlot.ring: cantAttackItem},
+      );
+
+      var state = GlobalState.test(
+        testRegistries,
+        equipment: equipment,
+        skillStates: const {
+          Skill.attack: SkillState(xp: 13034431, masteryPoolXp: 0),
+          Skill.strength: SkillState(xp: 13034431, masteryPoolXp: 0),
+          Skill.defence: SkillState(xp: 13034431, masteryPoolXp: 0),
+          Skill.hitpoints: SkillState(xp: 13034431, masteryPoolXp: 0),
+        },
+      );
+      state = _startCombat(state, plantMonster);
+
+      // Run enough ticks for a player attack cycle
+      final afterTicks = _runCombatTicks(state, 500);
+
+      // Monster HP should still be full since player can't attack
+      final combat = afterTicks.actionState(plantMonster.id).combat;
+      expect(combat, isNotNull);
+      expect(combat!.monsterHp, plantMonster.maxHp);
+    });
+  });
+
+  group('disableAttackDamage modifier', () {
+    test('player hits but deals zero damage', () {
+      final disableItem = _itemWithModifier(
+        'NoDamageRing',
+        'disableAttackDamage',
+        1,
+      );
+      final equipment = Equipment(
+        foodSlots: const [null, null, null],
+        selectedFoodSlot: 0,
+        gearSlots: {EquipmentSlot.ring: disableItem},
+      );
+
+      var state = GlobalState.test(
+        testRegistries,
+        equipment: equipment,
+        skillStates: const {
+          Skill.attack: SkillState(xp: 13034431, masteryPoolXp: 0),
+          Skill.strength: SkillState(xp: 13034431, masteryPoolXp: 0),
+          Skill.defence: SkillState(xp: 13034431, masteryPoolXp: 0),
+          Skill.hitpoints: SkillState(xp: 13034431, masteryPoolXp: 0),
+        },
+      );
+      state = _startCombat(state, plantMonster);
+
+      // Run enough ticks for several attack cycles
+      final afterTicks = _runCombatTicks(state, 500);
+
+      // Monster should be at full HP (damage disabled)
+      final combat = afterTicks.actionState(plantMonster.id).combat;
+      expect(combat, isNotNull);
+      expect(combat!.monsterHp, plantMonster.maxHp);
+    });
+  });
+
+  group('attackRolls modifier', () {
+    test('extra attack rolls deal more damage than baseline', () {
+      // Baseline: no extra rolls
+      var baseState = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.attack: SkillState(xp: 13034431, masteryPoolXp: 0),
+          Skill.strength: SkillState(xp: 13034431, masteryPoolXp: 0),
+          Skill.defence: SkillState(xp: 13034431, masteryPoolXp: 0),
+          Skill.hitpoints: SkillState(xp: 13034431, masteryPoolXp: 0),
+        },
+      );
+      baseState = _startCombat(baseState, plantMonster);
+
+      // With extra rolls
+      final extraRollsItem = _itemWithModifier(
+        'ExtraRollsRing',
+        'attackRolls',
+        2,
+      );
+      final equipment = Equipment(
+        foodSlots: const [null, null, null],
+        selectedFoodSlot: 0,
+        gearSlots: {EquipmentSlot.ring: extraRollsItem},
+      );
+      var bonusState = GlobalState.test(
+        testRegistries,
+        equipment: equipment,
+        skillStates: const {
+          Skill.attack: SkillState(xp: 13034431, masteryPoolXp: 0),
+          Skill.strength: SkillState(xp: 13034431, masteryPoolXp: 0),
+          Skill.defence: SkillState(xp: 13034431, masteryPoolXp: 0),
+          Skill.hitpoints: SkillState(xp: 13034431, masteryPoolXp: 0),
+        },
+      );
+      bonusState = _startCombat(bonusState, plantMonster);
+
+      // Use the same seed for both, run enough ticks for one attack cycle
+      const seed = 99;
+      final baseAfter = _runCombatTicks(baseState, 500, seed: seed);
+      final bonusAfter = _runCombatTicks(bonusState, 500, seed: seed);
+
+      final baseHp = baseAfter.actionState(plantMonster.id).combat?.monsterHp;
+      final bonusHp = bonusAfter.actionState(plantMonster.id).combat?.monsterHp;
+
+      // With extra rolls, monster should have taken more damage (lower HP)
+      // or the monster died (HP == 0 or null due to respawn)
+      if (baseHp != null && bonusHp != null) {
+        expect(bonusHp, lessThanOrEqualTo(baseHp));
+      }
+      // If bonus killed the monster, that's also valid - more damage was dealt
+    });
+  });
+
+  group('cantEvade modifier', () {
+    test('monster always hits when player has cantEvade', () {
+      final cantEvadeItem = _itemWithModifier('CantEvadeRing', 'cantEvade', 1);
+      final equipment = Equipment(
+        foodSlots: const [null, null, null],
+        selectedFoodSlot: 0,
+        gearSlots: {EquipmentSlot.ring: cantEvadeItem},
+      );
+
+      // Use very high defence so normally monster would miss most attacks
+      var state = GlobalState.test(
+        testRegistries,
+        equipment: equipment,
+        skillStates: const {
+          Skill.attack: SkillState(xp: 13034431, masteryPoolXp: 0),
+          Skill.strength: SkillState(xp: 13034431, masteryPoolXp: 0),
+          Skill.defence: SkillState(xp: 13034431, masteryPoolXp: 0),
+          Skill.hitpoints: SkillState(xp: 13034431, masteryPoolXp: 0),
+        },
+      );
+      state = _startCombat(state, plantMonster);
+
+      // Run combat for a while - with cantEvade the monster should always hit
+      // and player should take damage
+      final afterTicks = _runCombatTicks(state, 500);
+
+      // Player should have taken damage (lostHp > 0)
+      expect(afterTicks.health.lostHp, greaterThan(0));
+    });
+  });
+
+  group('reflect damage modifiers', () {
+    test('reflectDamage reflects percentage of damage taken', () {
+      // 100% reflect - all damage taken is reflected back
+      final reflectItem = _itemWithModifier(
+        'ReflectShield',
+        'reflectDamage',
+        100,
+      );
+      final equipment = Equipment(
+        foodSlots: const [null, null, null],
+        selectedFoodSlot: 0,
+        gearSlots: {EquipmentSlot.shield: reflectItem},
+      );
+
+      var state = GlobalState.test(
+        testRegistries,
+        equipment: equipment,
+        skillStates: const {
+          // Low stats so plant can hit us
+          Skill.hitpoints: SkillState(xp: 13034431, masteryPoolXp: 0),
+        },
+      );
+      state = _startCombat(state, plantMonster);
+
+      // Run enough ticks for the monster to attack
+      final afterTicks = _runCombatTicks(state, 500);
+
+      // Check if monster took reflect damage (HP below max)
+      final combat = afterTicks.actionState(plantMonster.id).combat;
+      if (combat != null && afterTicks.health.lostHp > 0) {
+        // If player took damage, monster should also have taken reflect damage
+        expect(combat.monsterHp, lessThan(plantMonster.maxHp));
+      }
+    });
+
+    test('flatReflectDamage deals flat damage per hit received', () {
+      final flatReflectItem = _itemWithModifier(
+        'FlatReflectShield',
+        'flatReflectDamage',
+        5,
+      );
+      final equipment = Equipment(
+        foodSlots: const [null, null, null],
+        selectedFoodSlot: 0,
+        gearSlots: {EquipmentSlot.shield: flatReflectItem},
+      );
+
+      var state = GlobalState.test(
+        testRegistries,
+        equipment: equipment,
+        skillStates: const {
+          Skill.hitpoints: SkillState(xp: 13034431, masteryPoolXp: 0),
+        },
+      );
+      state = _startCombat(state, plantMonster);
+
+      // Baseline without reflect
+      var baseState = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.hitpoints: SkillState(xp: 13034431, masteryPoolXp: 0),
+        },
+      );
+      baseState = _startCombat(baseState, plantMonster);
+
+      const seed = 55;
+      final reflectAfter = _runCombatTicks(state, 500, seed: seed);
+      final baseAfter = _runCombatTicks(baseState, 500, seed: seed);
+
+      final reflectHp = reflectAfter
+          .actionState(plantMonster.id)
+          .combat
+          ?.monsterHp;
+      final baseHp = baseAfter.actionState(plantMonster.id).combat?.monsterHp;
+
+      // With flat reflect, monster should have taken more damage
+      if (reflectHp != null && baseHp != null) {
+        expect(reflectHp, lessThanOrEqualTo(baseHp));
+      }
+    });
+  });
+
+  group('type-specific resistance modifiers', () {
+    test('damageReductionAgainst includes type-specific resistance', () {
+      // This is a pure unit test on PlayerCombatStats
+      const stats = PlayerCombatStats(
+        minHit: 1,
+        maxHit: 10,
+        damageReduction: 0.10,
+        attackSpeed: 3.0,
+        accuracy: 100,
+        meleeEvasion: 100,
+        rangedEvasion: 100,
+        magicEvasion: 100,
+        flatResistanceAgainstMelee: 10,
+        flatResistanceAgainstRanged: 5,
+        flatResistanceAgainstMagic: 15,
+        flatResistanceAgainstSlayerTasks: 3,
+        isFightingSlayerTask: true,
+      );
+
+      // Melee: 10% + 10% melee + 3% slayer = 23%
+      expect(
+        stats.damageReductionAgainst(AttackType.melee),
+        closeTo(0.23, 0.001),
+      );
+      // Ranged: 10% + 5% ranged + 3% slayer = 18%
+      expect(
+        stats.damageReductionAgainst(AttackType.ranged),
+        closeTo(0.18, 0.001),
+      );
+      // Magic: 10% + 15% magic + 3% slayer = 28%
+      expect(
+        stats.damageReductionAgainst(AttackType.magic),
+        closeTo(0.28, 0.001),
+      );
+    });
+  });
+}

--- a/logic/test/combat_stats_test.dart
+++ b/logic/test/combat_stats_test.dart
@@ -1325,4 +1325,225 @@ void main() {
       expect(statsWithContext.maxHit, statsEmpty.maxHit);
     });
   });
+
+  group('damageReductionAgainst', () {
+    test('returns base DR when no type-specific resistance', () {
+      const stats = PlayerCombatStats(
+        minHit: 1,
+        maxHit: 10,
+        damageReduction: 0.20,
+        attackSpeed: 3.0,
+        accuracy: 100,
+        meleeEvasion: 100,
+        rangedEvasion: 100,
+        magicEvasion: 100,
+        flatResistanceAgainstMelee: 0,
+        flatResistanceAgainstRanged: 0,
+        flatResistanceAgainstMagic: 0,
+        flatResistanceAgainstSlayerTasks: 0,
+        isFightingSlayerTask: false,
+      );
+
+      expect(stats.damageReductionAgainst(AttackType.melee), 0.20);
+      expect(stats.damageReductionAgainst(AttackType.ranged), 0.20);
+      expect(stats.damageReductionAgainst(AttackType.magic), 0.20);
+    });
+
+    test('adds melee-specific resistance against melee attacks', () {
+      const stats = PlayerCombatStats(
+        minHit: 1,
+        maxHit: 10,
+        damageReduction: 0.20,
+        attackSpeed: 3.0,
+        accuracy: 100,
+        meleeEvasion: 100,
+        rangedEvasion: 100,
+        magicEvasion: 100,
+        flatResistanceAgainstMelee: 10, // +10% DR vs melee
+        flatResistanceAgainstRanged: 0,
+        flatResistanceAgainstMagic: 0,
+        flatResistanceAgainstSlayerTasks: 0,
+        isFightingSlayerTask: false,
+      );
+
+      expect(
+        stats.damageReductionAgainst(AttackType.melee),
+        closeTo(0.30, 0.001),
+      );
+      // Other types unaffected
+      expect(stats.damageReductionAgainst(AttackType.ranged), 0.20);
+      expect(stats.damageReductionAgainst(AttackType.magic), 0.20);
+    });
+
+    test('adds ranged-specific resistance against ranged attacks', () {
+      const stats = PlayerCombatStats(
+        minHit: 1,
+        maxHit: 10,
+        damageReduction: 0.10,
+        attackSpeed: 3.0,
+        accuracy: 100,
+        meleeEvasion: 100,
+        rangedEvasion: 100,
+        magicEvasion: 100,
+        flatResistanceAgainstMelee: 0,
+        flatResistanceAgainstRanged: 15,
+        flatResistanceAgainstMagic: 0,
+        flatResistanceAgainstSlayerTasks: 0,
+        isFightingSlayerTask: false,
+      );
+
+      expect(
+        stats.damageReductionAgainst(AttackType.ranged),
+        closeTo(0.25, 0.001),
+      );
+      expect(stats.damageReductionAgainst(AttackType.melee), 0.10);
+    });
+
+    test('adds magic-specific resistance against magic attacks', () {
+      const stats = PlayerCombatStats(
+        minHit: 1,
+        maxHit: 10,
+        damageReduction: 0.10,
+        attackSpeed: 3.0,
+        accuracy: 100,
+        meleeEvasion: 100,
+        rangedEvasion: 100,
+        magicEvasion: 100,
+        flatResistanceAgainstMelee: 0,
+        flatResistanceAgainstRanged: 0,
+        flatResistanceAgainstMagic: 20,
+        flatResistanceAgainstSlayerTasks: 0,
+        isFightingSlayerTask: false,
+      );
+
+      expect(
+        stats.damageReductionAgainst(AttackType.magic),
+        closeTo(0.30, 0.001),
+      );
+      expect(stats.damageReductionAgainst(AttackType.melee), 0.10);
+    });
+
+    test('adds slayer task resistance when fighting slayer task', () {
+      const stats = PlayerCombatStats(
+        minHit: 1,
+        maxHit: 10,
+        damageReduction: 0.20,
+        attackSpeed: 3.0,
+        accuracy: 100,
+        meleeEvasion: 100,
+        rangedEvasion: 100,
+        magicEvasion: 100,
+        flatResistanceAgainstMelee: 0,
+        flatResistanceAgainstRanged: 0,
+        flatResistanceAgainstMagic: 0,
+        flatResistanceAgainstSlayerTasks: 5, // +5% DR on slayer tasks
+        isFightingSlayerTask: true,
+      );
+
+      // All attack types get the bonus during slayer tasks
+      expect(
+        stats.damageReductionAgainst(AttackType.melee),
+        closeTo(0.25, 0.001),
+      );
+      expect(
+        stats.damageReductionAgainst(AttackType.ranged),
+        closeTo(0.25, 0.001),
+      );
+      expect(
+        stats.damageReductionAgainst(AttackType.magic),
+        closeTo(0.25, 0.001),
+      );
+    });
+
+    test('slayer task resistance not applied when not on task', () {
+      const stats = PlayerCombatStats(
+        minHit: 1,
+        maxHit: 10,
+        damageReduction: 0.20,
+        attackSpeed: 3.0,
+        accuracy: 100,
+        meleeEvasion: 100,
+        rangedEvasion: 100,
+        magicEvasion: 100,
+        flatResistanceAgainstMelee: 0,
+        flatResistanceAgainstRanged: 0,
+        flatResistanceAgainstMagic: 0,
+        flatResistanceAgainstSlayerTasks: 5,
+        isFightingSlayerTask: false,
+      );
+
+      expect(stats.damageReductionAgainst(AttackType.melee), 0.20);
+    });
+
+    test('stacks type-specific and slayer task resistance', () {
+      const stats = PlayerCombatStats(
+        minHit: 1,
+        maxHit: 10,
+        damageReduction: 0.10,
+        attackSpeed: 3.0,
+        accuracy: 100,
+        meleeEvasion: 100,
+        rangedEvasion: 100,
+        magicEvasion: 100,
+        flatResistanceAgainstMelee: 10,
+        flatResistanceAgainstRanged: 0,
+        flatResistanceAgainstMagic: 0,
+        flatResistanceAgainstSlayerTasks: 5,
+        isFightingSlayerTask: true,
+      );
+
+      // Melee: 10% base + 10% melee + 5% slayer = 25%
+      expect(
+        stats.damageReductionAgainst(AttackType.melee),
+        closeTo(0.25, 0.001),
+      );
+      // Ranged: 10% base + 5% slayer = 15%
+      expect(
+        stats.damageReductionAgainst(AttackType.ranged),
+        closeTo(0.15, 0.001),
+      );
+    });
+
+    test('clamps total DR to 95%', () {
+      const stats = PlayerCombatStats(
+        minHit: 1,
+        maxHit: 10,
+        damageReduction: 0.90,
+        attackSpeed: 3.0,
+        accuracy: 100,
+        meleeEvasion: 100,
+        rangedEvasion: 100,
+        magicEvasion: 100,
+        flatResistanceAgainstMelee: 20,
+        flatResistanceAgainstRanged: 0,
+        flatResistanceAgainstMagic: 0,
+        flatResistanceAgainstSlayerTasks: 0,
+        isFightingSlayerTask: false,
+      );
+
+      // 90% + 20% = 110%, clamped to 95%
+      expect(stats.damageReductionAgainst(AttackType.melee), 0.95);
+    });
+
+    test('random attack type returns base DR only', () {
+      const stats = PlayerCombatStats(
+        minHit: 1,
+        maxHit: 10,
+        damageReduction: 0.20,
+        attackSpeed: 3.0,
+        accuracy: 100,
+        meleeEvasion: 100,
+        rangedEvasion: 100,
+        magicEvasion: 100,
+        flatResistanceAgainstMelee: 10,
+        flatResistanceAgainstRanged: 10,
+        flatResistanceAgainstMagic: 10,
+        flatResistanceAgainstSlayerTasks: 0,
+        isFightingSlayerTask: false,
+      );
+
+      // Random attack type doesn't get any type-specific bonus
+      expect(stats.damageReductionAgainst(AttackType.random), 0.20);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Implement consumption of 11 previously-unused combat modifiers: `attackRolls`, `cantAttack`, `cantEvade`, `disableAttackDamage`, `reflectDamage`, `rolledReflectDamage`, `flatReflectDamage`, `flatResistanceAgainstMelee`, `flatResistanceAgainstRanged`, `flatResistanceAgainstMagic`, `flatResistanceAgainstSlayerTasks`
- Add `damageReductionAgainst(AttackType)` method to `PlayerCombatStats` for computing effective damage reduction including type-specific and slayer task bonuses
- Make `PlayerCombatStats` constructor `@visibleForTesting` and add optional `modifiers` parameter to `Item.test()` for easier test setup

## Key changes
- **combat_stats.dart**: Store per-type flat resistance and slayer task resistance on `PlayerCombatStats`, add `damageReductionAgainst()` helper
- **consume_ticks.dart**: Player attack phase checks `cantAttack`, `disableAttackDamage`, and `attackRolls`; monster attack phase checks `cantEvade` and applies reflect damage + type-specific DR
- **items.dart**: `Item.test()` now accepts optional `modifiers` parameter

## Deferred to issues
- `effectIgnoreChance`/`effectImmunity` - require combat effect infrastructure (#244)
- `stunDurationIncreaseChance`/`onHitSlowMagnitude` - require stun/slow effect infrastructure (#245)

## Test plan
- [x] Unit tests for `damageReductionAgainst()` with all combinations (type-specific, slayer, stacking, clamping)
- [x] Integration tests for `cantAttack`, `disableAttackDamage`, `attackRolls`, `cantEvade`, `reflectDamage`, `flatReflectDamage`
- [x] All existing tests pass (`dart test -r failures-only`)
- [x] `dart format .` applied