### PR TITLE
feat: consume HP regen and healing modifiers

### DIFF
--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -145,38 +145,144 @@ MiningState applyMiningTicks(MiningState miningState, Tick ticksElapsed) {
 /// Result of applying HP regen ticks to player health.
 typedef PlayerHpRegenResult = ({HealthState state, Tick ticksConsumed});
 
+/// Pre-computed HP regen parameters from modifiers.
+///
+/// Computed once per background tick batch to avoid repeated modifier lookups.
+@immutable
+class HpRegenParams {
+  const HpRegenParams({
+    this.hitpointRegeneration = 0,
+    this.flatHPRegen = 0,
+    this.flatRegenerationInterval = 0,
+    this.flatHPRegenBasedOnMaxHit = 0,
+    this.hpRegenWhenEnemyHasMoreEvasion = 0,
+    this.hitpointRegenerationAgainstSlayerTasks = 0,
+  });
+
+  /// Builds regen parameters from modifier accessors and combat state.
+  factory HpRegenParams.fromModifiers(
+    ModifierAccessors modifiers, {
+    required int currentMaxHit,
+    required CombatType? currentCombatType,
+    required bool enemyHasMoreEvasion,
+    required bool isFightingSlayerTask,
+  }) {
+    final flatRegenFromMaxHit = _flatHpRegenFromMaxHit(
+      modifiers,
+      currentMaxHit: currentMaxHit,
+      combatType: currentCombatType,
+    );
+
+    return HpRegenParams(
+      hitpointRegeneration: modifiers.hitpointRegeneration,
+      flatHPRegen: modifiers.flatHPRegen,
+      flatRegenerationInterval: modifiers.flatRegenerationInterval,
+      flatHPRegenBasedOnMaxHit: flatRegenFromMaxHit,
+      hpRegenWhenEnemyHasMoreEvasion: enemyHasMoreEvasion
+          ? modifiers.hpRegenWhenEnemyHasMoreEvasion
+          : 0,
+      hitpointRegenerationAgainstSlayerTasks: isFightingSlayerTask
+          ? modifiers.hitpointRegenerationAgainstSlayerTasks
+          : 0,
+    );
+  }
+
+  /// No modifiers applied (default regen behavior).
+  static const none = HpRegenParams();
+
+  /// Percentage modifier to HP regen amount (e.g. 10 = +10%).
+  final double hitpointRegeneration;
+
+  /// Flat bonus HP per regen tick.
+  final double flatHPRegen;
+
+  /// Flat modifier to regen interval in milliseconds.
+  final int flatRegenerationInterval;
+
+  /// Flat HP regen from max-hit-based modifiers (already resolved).
+  final int flatHPRegenBasedOnMaxHit;
+
+  /// Extra flat regen when enemy has higher evasion than player accuracy.
+  final int hpRegenWhenEnemyHasMoreEvasion;
+
+  /// Extra percentage regen against slayer task monsters.
+  final int hitpointRegenerationAgainstSlayerTasks;
+
+  /// Computes the flat HP regen contribution from max-hit-based modifiers.
+  static int _flatHpRegenFromMaxHit(
+    ModifierAccessors modifiers, {
+    required int currentMaxHit,
+    required CombatType? combatType,
+  }) {
+    if (combatType == null || currentMaxHit <= 0) return 0;
+    final percent = switch (combatType) {
+      CombatType.melee => modifiers.flatHPRegenBasedOnMeleeMaxHit,
+      CombatType.ranged => modifiers.flatHPRegenBasedOnRangedMaxHit,
+      CombatType.magic => modifiers.flatHPRegenBasedOnMagicMaxHit,
+    };
+    if (percent <= 0) return 0;
+    return (currentMaxHit * percent / 100).floor();
+  }
+}
+
 /// Applies HP regeneration ticks to player health.
-/// Heals 1% of max HP every 10 seconds while injured.
+///
+/// Base regen: 1% of max HP every 10 seconds (100 ticks).
+/// Modifiers in [params] adjust the heal amount, regen interval,
+/// and add flat bonuses.
 PlayerHpRegenResult _applyPlayerHpRegenTicks(
   HealthState health,
   int maxPlayerHp,
-  Tick ticksAvailable,
-) {
+  Tick ticksAvailable, {
+  HpRegenParams params = HpRegenParams.none,
+}) {
   if (health.isFullHealth) {
     return (state: health, ticksConsumed: 0);
   }
 
   var lostHp = health.lostHp;
+  // Effective regen interval: base 10s + flatRegenerationInterval (ms).
+  final effectiveIntervalMs = 10000 + params.flatRegenerationInterval;
+  final effectiveInterval = max(
+    1,
+    ticksFromDuration(Duration(milliseconds: effectiveIntervalMs)),
+  );
   var ticksUntilNextHeal = health.hpRegenTicksRemaining;
 
-  // If regen timer not started, start it
+  // If regen timer not started, start it.
   if (ticksUntilNextHeal == 0 && lostHp > 0) {
-    ticksUntilNextHeal = hpRegenTickInterval;
+    ticksUntilNextHeal = effectiveInterval;
   }
 
   var ticksRemaining = ticksAvailable;
 
-  // Calculate heal amount (1% of max HP, minimum 1)
-  final healPerTick = max(1, (maxPlayerHp * 0.01).round());
+  // Base heal: 1% of max HP, minimum 1.
+  var baseHeal = max(1, (maxPlayerHp * 0.01).round());
 
-  // Apply heals while we have HP to regen and enough ticks
+  // Apply percentage modifiers (hitpointRegeneration +
+  // hitpointRegenerationAgainstSlayerTasks).
+  final totalPercent =
+      params.hitpointRegeneration +
+      params.hitpointRegenerationAgainstSlayerTasks;
+  if (totalPercent != 0) {
+    baseHeal = max(1, (baseHeal * (1 + totalPercent / 100)).round());
+  }
+
+  // Add flat bonuses.
+  final flatBonus =
+      params.flatHPRegen.round() +
+      params.flatHPRegenBasedOnMaxHit +
+      params.hpRegenWhenEnemyHasMoreEvasion;
+  final healPerTick = max(1, baseHeal + flatBonus);
+
+  // Apply heals while we have HP to regen and enough ticks.
   while (lostHp > 0 && ticksRemaining >= ticksUntilNextHeal) {
     ticksRemaining -= ticksUntilNextHeal;
     lostHp = max(0, lostHp - healPerTick);
-    ticksUntilNextHeal = hpRegenTickInterval;
+    ticksUntilNextHeal = effectiveInterval;
   }
 
-  // Apply partial progress toward next heal if we still have HP to regen
+  // Apply partial progress toward next heal if we still have HP to regen.
   if (lostHp > 0) {
     ticksUntilNextHeal -= ticksRemaining;
     ticksRemaining = 0;
@@ -283,6 +389,70 @@ List<BackgroundTickConsumer> _getBackgroundActions(
   return backgrounds;
 }
 
+/// Builds [HpRegenParams] from the current game state and active combat.
+///
+/// When the player is in combat, reads combat modifiers, player stats, and
+/// monster stats to populate context-sensitive regen bonuses. Outside combat,
+/// returns [HpRegenParams.none] (standard regen only).
+HpRegenParams _buildHpRegenParams(GlobalState state, ActionId? activeActionId) {
+  // Only compute combat-aware regen when in combat.
+  final activity = state.activeActivity;
+  if (activity is! CombatActivity || activeActionId == null) {
+    // Outside combat, still check for non-combat regen modifiers.
+    final modifiers = state.createGlobalModifierProvider(
+      conditionContext: ConditionContext.empty,
+    );
+    return HpRegenParams(
+      hitpointRegeneration: modifiers.hitpointRegeneration,
+      flatHPRegen: modifiers.flatHPRegen,
+      flatRegenerationInterval: modifiers.flatRegenerationInterval,
+    );
+  }
+
+  final combatState = state.actionState(activeActionId).combat;
+  if (combatState == null) return HpRegenParams.none;
+
+  final action = state.registries.combat.monsterById(
+    combatState.monsterId.localId,
+  );
+  final monsterHp = combatState.monsterHp;
+
+  final conditionContext = state.buildCombatConditionContext(
+    enemyAction: action,
+    enemyCurrentHp: monsterHp,
+  );
+  final modifiers = state.createCombatModifierProvider(
+    conditionContext: conditionContext,
+  );
+
+  final pStats = computePlayerStats(state, conditionContext: conditionContext);
+  final mStats = MonsterCombatStats.fromAction(action);
+
+  // Determine if enemy has more evasion than player accuracy.
+  // Compare monster evasion (for the player's attack type) vs player accuracy.
+  final playerCombatType = state.attackStyle.combatType;
+  final playerAttackType = switch (playerCombatType) {
+    CombatType.melee => AttackType.melee,
+    CombatType.ranged => AttackType.ranged,
+    CombatType.magic => AttackType.magic,
+  };
+  final monsterEvasion = switch (playerAttackType) {
+    AttackType.melee => mStats.meleeEvasion,
+    AttackType.ranged => mStats.rangedEvasion,
+    AttackType.magic => mStats.magicEvasion,
+    AttackType.random => mStats.meleeEvasion,
+  };
+  final enemyHasMoreEvasion = monsterEvasion > pStats.accuracy;
+
+  return HpRegenParams.fromModifiers(
+    modifiers,
+    currentMaxHit: pStats.maxHit,
+    currentCombatType: state.attackStyle.combatType,
+    enemyHasMoreEvasion: enemyHasMoreEvasion,
+    isFightingSlayerTask: conditionContext.isFightingSlayerTask,
+  );
+}
+
 /// Applies ticks to all background actions and updates the builder.
 /// Re-reads the current state from the builder to avoid stale data issues
 /// when foreground and background both modify the same action's state.
@@ -296,13 +466,15 @@ void _applyBackgroundTicks(
   // Note: stun countdown is handled by the foreground (it blocks the
   // foreground action, so the foreground owns the lifecycle).
 
-  // Apply player HP regeneration
+  // Apply player HP regeneration with modifier support.
   final health = builder.state.health;
   if (!health.isFullHealth) {
+    final regenParams = _buildHpRegenParams(builder.state, activeActionId);
     final result = _applyPlayerHpRegenTicks(
       health,
       builder.state.maxPlayerHp,
       ticks,
+      params: regenParams,
     );
     builder.setHealth(result.state);
   }
@@ -1413,6 +1585,20 @@ ForegroundResult _restartOrStop(
       );
       for (final entry in xpGrant.xpGrants.entries) {
         builder.addSkillXp(entry.key, entry.value);
+      }
+
+      // Heal on attack based on resistance.
+      final healOnAttackCtx = builder.state.createCombatModifierProvider(
+        conditionContext: combatContext,
+      );
+      final healResistPct = healOnAttackCtx.healingOnAttackBasedOnResistance;
+      if (healResistPct > 0) {
+        final resistance = pStats.damageReduction * 100;
+        final healAmount = (resistance * healResistPct / 100).floor();
+        if (healAmount > 0) {
+          health = health.heal(healAmount);
+          builder.setHealth(health);
+        }
       }
     }
     // Miss: no damage dealt, no XP granted

--- a/logic/lib/src/state_update_builder.dart
+++ b/logic/lib/src/state_update_builder.dart
@@ -528,8 +528,12 @@ class StateUpdateBuilder {
 
       if (food == null) break;
 
-      final healAmount = food.item.healsFor;
-      if (healAmount == null || healAmount <= 0) break;
+      final baseHeal = food.item.healsFor;
+      if (baseHeal == null || baseHeal <= 0) break;
+
+      // Add foodHealingValue modifier (flat HP bonus per food item).
+      final foodBonus = modifiers.foodHealingValue(actionId: food.item.id);
+      final healAmount = baseHeal + foodBonus;
 
       // Apply efficiency to heal amount
       final effectiveHeal = (healAmount * efficiency / 100).ceil();

--- a/logic/test/hp_regen_modifiers_test.dart
+++ b/logic/test/hp_regen_modifiers_test.dart
@@ -1,0 +1,301 @@
+import 'dart:math';
+
+import 'package:logic/logic.dart';
+import 'package:test/test.dart';
+
+import 'test_helper.dart';
+import 'test_modifiers.dart';
+
+void main() {
+  setUpAll(() async {
+    await loadTestRegistries();
+  });
+
+  group('HpRegenParams', () {
+    test('none has all-zero values', () {
+      const params = HpRegenParams.none;
+      expect(params.hitpointRegeneration, 0);
+      expect(params.flatHPRegen, 0);
+      expect(params.flatRegenerationInterval, 0);
+      expect(params.flatHPRegenBasedOnMaxHit, 0);
+      expect(params.hpRegenWhenEnemyHasMoreEvasion, 0);
+      expect(params.hitpointRegenerationAgainstSlayerTasks, 0);
+    });
+
+    test('fromModifiers reads hitpointRegeneration', () {
+      const modifiers = TestModifiers({'hitpointRegeneration': 50});
+      final params = HpRegenParams.fromModifiers(
+        modifiers,
+        currentMaxHit: 100,
+        currentCombatType: CombatType.melee,
+        enemyHasMoreEvasion: false,
+        isFightingSlayerTask: false,
+      );
+      expect(params.hitpointRegeneration, 50);
+    });
+
+    test('fromModifiers reads flatHPRegen', () {
+      const modifiers = TestModifiers({'flatHPRegen': 5});
+      final params = HpRegenParams.fromModifiers(
+        modifiers,
+        currentMaxHit: 100,
+        currentCombatType: CombatType.melee,
+        enemyHasMoreEvasion: false,
+        isFightingSlayerTask: false,
+      );
+      expect(params.flatHPRegen, 5);
+    });
+
+    test('fromModifiers reads flatRegenerationInterval', () {
+      const modifiers = TestModifiers({'flatRegenerationInterval': -2000});
+      final params = HpRegenParams.fromModifiers(
+        modifiers,
+        currentMaxHit: 100,
+        currentCombatType: CombatType.melee,
+        enemyHasMoreEvasion: false,
+        isFightingSlayerTask: false,
+      );
+      expect(params.flatRegenerationInterval, -2000);
+    });
+
+    test('fromModifiers computes flatHPRegenBasedOnMeleeMaxHit', () {
+      const modifiers = TestModifiers({'flatHPRegenBasedOnMeleeMaxHit': 10});
+      final params = HpRegenParams.fromModifiers(
+        modifiers,
+        currentMaxHit: 200,
+        currentCombatType: CombatType.melee,
+        enemyHasMoreEvasion: false,
+        isFightingSlayerTask: false,
+      );
+      // 10% of 200 = 20
+      expect(params.flatHPRegenBasedOnMaxHit, 20);
+    });
+
+    test('fromModifiers computes flatHPRegenBasedOnRangedMaxHit', () {
+      const modifiers = TestModifiers({'flatHPRegenBasedOnRangedMaxHit': 15});
+      final params = HpRegenParams.fromModifiers(
+        modifiers,
+        currentMaxHit: 100,
+        currentCombatType: CombatType.ranged,
+        enemyHasMoreEvasion: false,
+        isFightingSlayerTask: false,
+      );
+      // 15% of 100 = 15
+      expect(params.flatHPRegenBasedOnMaxHit, 15);
+    });
+
+    test('fromModifiers computes flatHPRegenBasedOnMagicMaxHit', () {
+      const modifiers = TestModifiers({'flatHPRegenBasedOnMagicMaxHit': 20});
+      final params = HpRegenParams.fromModifiers(
+        modifiers,
+        currentMaxHit: 150,
+        currentCombatType: CombatType.magic,
+        enemyHasMoreEvasion: false,
+        isFightingSlayerTask: false,
+      );
+      // 20% of 150 = 30
+      expect(params.flatHPRegenBasedOnMaxHit, 30);
+    });
+
+    test('maxHit-based regen is zero when combat type does not match', () {
+      // Modifier for melee, but player is using ranged.
+      const modifiers = TestModifiers({'flatHPRegenBasedOnMeleeMaxHit': 10});
+      final params = HpRegenParams.fromModifiers(
+        modifiers,
+        currentMaxHit: 200,
+        currentCombatType: CombatType.ranged,
+        enemyHasMoreEvasion: false,
+        isFightingSlayerTask: false,
+      );
+      expect(params.flatHPRegenBasedOnMaxHit, 0);
+    });
+
+    test('maxHit-based regen is zero outside combat', () {
+      const modifiers = TestModifiers({'flatHPRegenBasedOnMeleeMaxHit': 10});
+      final params = HpRegenParams.fromModifiers(
+        modifiers,
+        currentMaxHit: 0,
+        currentCombatType: null,
+        enemyHasMoreEvasion: false,
+        isFightingSlayerTask: false,
+      );
+      expect(params.flatHPRegenBasedOnMaxHit, 0);
+    });
+
+    test(
+      'hpRegenWhenEnemyHasMoreEvasion only applies when enemy evasion higher',
+      () {
+        const modifiers = TestModifiers({'hpRegenWhenEnemyHasMoreEvasion': 3});
+
+        // Enemy has more evasion.
+        final paramsActive = HpRegenParams.fromModifiers(
+          modifiers,
+          currentMaxHit: 100,
+          currentCombatType: CombatType.melee,
+          enemyHasMoreEvasion: true,
+          isFightingSlayerTask: false,
+        );
+        expect(paramsActive.hpRegenWhenEnemyHasMoreEvasion, 3);
+
+        // Enemy does NOT have more evasion.
+        final paramsInactive = HpRegenParams.fromModifiers(
+          modifiers,
+          currentMaxHit: 100,
+          currentCombatType: CombatType.melee,
+          enemyHasMoreEvasion: false,
+          isFightingSlayerTask: false,
+        );
+        expect(paramsInactive.hpRegenWhenEnemyHasMoreEvasion, 0);
+      },
+    );
+
+    test('hitpointRegenerationAgainstSlayerTasks only applies on task', () {
+      const modifiers = TestModifiers({
+        'hitpointRegenerationAgainstSlayerTasks': 25,
+      });
+
+      final paramsOnTask = HpRegenParams.fromModifiers(
+        modifiers,
+        currentMaxHit: 100,
+        currentCombatType: CombatType.melee,
+        enemyHasMoreEvasion: false,
+        isFightingSlayerTask: true,
+      );
+      expect(paramsOnTask.hitpointRegenerationAgainstSlayerTasks, 25);
+
+      final paramsOffTask = HpRegenParams.fromModifiers(
+        modifiers,
+        currentMaxHit: 100,
+        currentCombatType: CombatType.melee,
+        enemyHasMoreEvasion: false,
+        isFightingSlayerTask: false,
+      );
+      expect(paramsOffTask.hitpointRegenerationAgainstSlayerTasks, 0);
+    });
+  });
+
+  group('_applyPlayerHpRegenTicks with modifiers', () {
+    // We test via consumeTicks since the regen function is private.
+    // The background tick path calls _applyPlayerHpRegenTicks.
+
+    test('base regen heals 1% of max HP every 10 seconds', () {
+      // Hitpoints level 10 = 100 maxHP. 1% = 1 HP per regen tick.
+      var state = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.hitpoints: SkillState(xp: 1154, masteryPoolXp: 0),
+        },
+        health: const HealthState(lostHp: 5),
+      );
+      expect(state.maxPlayerHp, 100);
+      expect(state.playerHp, 95);
+
+      // 100 ticks = 10 seconds = 1 regen tick
+      final builder = StateUpdateBuilder(state);
+      consumeTicks(builder, 100, random: _seededRandom());
+      state = builder.build();
+
+      // Should have healed 1 HP (1% of 100).
+      expect(state.health.lostHp, 4);
+    });
+
+    test('regen does nothing at full health', () {
+      var state = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.hitpoints: SkillState(xp: 1154, masteryPoolXp: 0),
+        },
+      );
+      expect(state.health.isFullHealth, true);
+
+      final builder = StateUpdateBuilder(state);
+      consumeTicks(builder, 200, random: _seededRandom());
+      state = builder.build();
+
+      expect(state.health.isFullHealth, true);
+    });
+
+    test('multiple regen ticks heal multiple times', () {
+      var state = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.hitpoints: SkillState(xp: 1154, masteryPoolXp: 0),
+        },
+        health: const HealthState(lostHp: 10),
+      );
+      expect(state.maxPlayerHp, 100);
+
+      // 300 ticks = 30 seconds = 3 regen ticks, heals 3 HP.
+      final builder = StateUpdateBuilder(state);
+      consumeTicks(builder, 300, random: _seededRandom());
+      state = builder.build();
+
+      expect(state.health.lostHp, 7);
+    });
+  });
+
+  group('foodHealingValue modifier', () {
+    late Item shrimp;
+
+    setUpAll(() {
+      shrimp = testItems.byName('Shrimp');
+    });
+
+    test('foodHealingValue adds flat HP to food healing', () {
+      final equipment = Equipment(
+        foodSlots: [ItemStack(shrimp, count: 10), null, null],
+        selectedFoodSlot: 0,
+      );
+      // Hitpoints level 1 = 10 maxHP. lostHp 9 = 1 HP.
+      final state = GlobalState.test(
+        testRegistries,
+        equipment: equipment,
+        health: const HealthState(lostHp: 9),
+      );
+
+      final builder = StateUpdateBuilder(state);
+      // foodHealingValue of 20 adds 20 to shrimp's base heal (30).
+      // Total heal = 50 per food. Efficiency 100%.
+      // Auto-eat threshold 50 = eat when HP < 5 (player at 1).
+      // HP limit 100 = eat until full (10 HP).
+      // Need to heal 9 lost HP. 50 per food = 1 food eaten (heals to full).
+      const modifiers = TestModifiers({
+        'autoEatThreshold': 50,
+        'autoEatEfficiency': 100,
+        'autoEatHPLimit': 100,
+        'foodHealingValue': 20,
+      });
+      final consumed = builder.tryAutoEat(modifiers);
+
+      expect(consumed, 1);
+      // Healed 50 HP (30 base + 20 bonus), but only 9 lost, so full.
+      expect(builder.state.health.lostHp, 0);
+    });
+
+    test('foodHealingValue of 0 uses base healing only', () {
+      final equipment = Equipment(
+        foodSlots: [ItemStack(shrimp, count: 10), null, null],
+        selectedFoodSlot: 0,
+      );
+      final state = GlobalState.test(
+        testRegistries,
+        equipment: equipment,
+        health: const HealthState(lostHp: 9),
+      );
+
+      final builder = StateUpdateBuilder(state);
+      const modifiers = TestModifiers({
+        'autoEatThreshold': 50,
+        'autoEatEfficiency': 100,
+        'autoEatHPLimit': 100,
+      });
+      final consumed = builder.tryAutoEat(modifiers);
+
+      expect(consumed, 1);
+      // Shrimp heals 30, only lost 9, so fully healed.
+      expect(builder.state.health.lostHp, 0);
+    });
+  });
+}
+
+Random _seededRandom() => Random(42);


### PR DESCRIPTION
## Summary
- Add `HpRegenParams` class to pre-compute HP regen modifier values once per background tick batch, avoiding repeated modifier lookups
- Wire 8 previously-unused regen/healing modifiers into the combat and auto-eat systems: `hitpointRegeneration`, `flatHPRegen`, `flatRegenerationInterval`, `flatHPRegenBasedOn{Melee,Ranged,Magic}MaxHit`, `hpRegenWhenEnemyHasMoreEvasion`, `hitpointRegenerationAgainstSlayerTasks`, `healingOnAttackBasedOnResistance`, `foodHealingValue`
- Modifier-based max hit regen only applies for the player's current combat type (melee/ranged/magic); computing off-type max hits is deferred

## Test plan
- [x] 16 new tests covering `HpRegenParams.fromModifiers` for each modifier, edge cases (no combat, mismatched type, on/off slayer task), and `foodHealingValue` in auto-eat
- [x] Integration tests verify base regen behavior through `consumeTicks`
- [x] Full test suite passes (2362 tests)
- [x] `dart analyze --fatal-infos` clean, `dart format` clean, `npx cspell` clean