### PR TITLE
feat: consume combat damage modifiers

### DIFF
--- a/logic/lib/src/combat_stats.dart
+++ b/logic/lib/src/combat_stats.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:logic/src/data/actions.dart';
 import 'package:logic/src/state.dart';
+import 'package:logic/src/types/modifier_names.dart';
 import 'package:logic/src/types/modifier_provider.dart';
 import 'package:meta/meta.dart';
 
@@ -499,6 +500,44 @@ PlayerCombatStats computePlayerStats(
   required ConditionContext conditionContext,
 }) {
   return PlayerCombatStats.fromState(state, conditionContext: conditionContext);
+}
+
+/// Extension on [ModifierAccessors] for combat damage modifier helpers.
+///
+/// These reduce repetitive switch statements when applying damage dealt,
+/// damage taken, and other combat-specific modifier calculations.
+extension CombatModifierHelpers on ModifierAccessors {
+  /// Returns the total percentage modifier to damage dealt against a monster.
+  ///
+  /// Combines:
+  /// - [damageDealt] - percentage bonus to all damage dealt
+  /// - [damageDealtToAllMonsters] - bonus vs all monsters
+  /// - [damageDealtToBosses] - bonus vs bosses (when [isBoss] is true)
+  /// - [damageDealtToSlayerTasks] - bonus vs slayer task monsters
+  ///   (when [isFightingSlayerTask] is true)
+  int totalDamageDealtModifier({
+    required bool isBoss,
+    required bool isFightingSlayerTask,
+  }) {
+    var modifier = damageDealt + damageDealtToAllMonsters;
+    if (isBoss) {
+      modifier += damageDealtToBosses;
+    }
+    if (isFightingSlayerTask) {
+      modifier += damageDealtToSlayerTasks;
+    }
+    return modifier;
+  }
+
+  /// Applies the [damageTaken] modifier to incoming damage.
+  ///
+  /// The `damageTaken` modifier is a percentage change to damage received.
+  /// Negative values reduce damage (e.g., -10 means 10% less damage taken).
+  int applyDamageTakenModifier(int damage) {
+    final modifier = damageTaken;
+    if (modifier == 0) return damage;
+    return (damage * (1 + modifier / 100)).floor().clamp(0, damage * 10);
+  }
 }
 
 /// XP grants from combat damage.

--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -1370,10 +1370,24 @@ ForegroundResult _restartOrStop(
     if (CombatCalculator.rollHit(random, hitChance)) {
       final baseDamage = pStats.rollDamage(random);
       // Apply combat triangle damage modifier
-      final damage = CombatTriangle.applyDamageModifier(
+      var damage = CombatTriangle.applyDamageModifier(
         baseDamage,
         triangleModifiers,
       );
+
+      // Apply damage dealt modifiers (damageDealt, damageDealtToAllMonsters,
+      // damageDealtToBosses, damageDealtToSlayerTasks).
+      final combatModifiers = builder.state.createCombatModifierProvider(
+        conditionContext: combatContext,
+      );
+      final damageDealtPct = combatModifiers.totalDamageDealtModifier(
+        isBoss: action.isBoss,
+        isFightingSlayerTask: combatContext.isFightingSlayerTask,
+      );
+      if (damageDealtPct != 0) {
+        damage = (damage * (1 + damageDealtPct / 100)).floor().clamp(0, 999999);
+      }
+
       monsterHp -= damage;
 
       // Grant combat XP based on damage dealt and attack style
@@ -1621,11 +1635,18 @@ ForegroundResult _restartOrStop(
     if (CombatCalculator.rollHit(random, hitChance)) {
       final damage = mStats.rollDamage(random);
       // Apply combat triangle to damage reduction
-      final reducedDamage = CombatTriangle.applyDamageReduction(
+      var reducedDamage = CombatTriangle.applyDamageReduction(
         damage,
         pStats.damageReduction,
         triangleModifiers,
       );
+
+      // Apply damageTaken modifier (negative = less damage taken).
+      final defenseModifiers = builder.state.createCombatModifierProvider(
+        conditionContext: combatCtx,
+      );
+      reducedDamage = defenseModifiers.applyDamageTakenModifier(reducedDamage);
+
       health = health.takeDamage(reducedDamage);
       builder.setHealth(health);
     }

--- a/logic/lib/src/state.dart
+++ b/logic/lib/src/state.dart
@@ -904,30 +904,24 @@ class GlobalState {
   /// This is the game data used to load the state.
   final Registries registries;
 
-  /// The player's base maximum HP (computed from Hitpoints skill level).
+  /// The player's base maximum HP from Hitpoints skill level alone.
   /// Each Hitpoints level grants 10 HP.
   ///
-  /// For the modified value that includes equipment bonuses, use
-  /// [maxPlayerHpWithModifiers].
-  int get maxPlayerHp {
+  /// Most callers should use [maxPlayerHp] which includes modifiers.
+  int get baseMaxPlayerHp {
     final hitpointsLevel = skillState(Skill.hitpoints).skillLevel;
     return hitpointsLevel * 10;
   }
 
-  /// The player's maximum HP including modifier bonuses.
+  /// The player's maximum HP including equipment and modifier bonuses.
   ///
   /// Applies `maxHitpoints` (percentage) and `flatMaxHitpoints` (flat bonus)
   /// on top of the base HP from Hitpoints skill level.
-  int maxPlayerHpWithModifiers(ModifierAccessors modifiers) {
-    var hp = maxPlayerHp;
-    // Apply percentage modifier first.
-    final pct = modifiers.maxHitpoints;
-    if (pct != 0) {
-      hp = (hp * (1 + pct / 100)).floor();
-    }
-    // Then apply flat bonus.
-    hp += modifiers.flatMaxHitpoints;
-    return hp.clamp(1, 999999);
+  int get maxPlayerHp {
+    final mods = createCombatModifierProvider(
+      conditionContext: ConditionContext.empty,
+    );
+    return applyMaxHpModifiers(baseMaxPlayerHp, mods);
   }
 
   /// The player's combat level using Melvor Idle formula.
@@ -4204,4 +4198,18 @@ class GlobalState {
     // Current potion charges + remaining inventory potions worth of charges
     return chargesLeft + (inventoryCount - 1) * chargesPerPotion;
   }
+}
+
+/// Applies max-HP modifiers to a base value.
+///
+/// Applies `maxHitpoints` (percentage) first, then `flatMaxHitpoints` (flat),
+/// and clamps the result to [1, 999999].
+int applyMaxHpModifiers(int baseHp, ModifierAccessors modifiers) {
+  var hp = baseHp;
+  final pct = modifiers.maxHitpoints;
+  if (pct != 0) {
+    hp = (hp * (1 + pct / 100)).floor();
+  }
+  hp += modifiers.flatMaxHitpoints;
+  return hp.clamp(1, 999999);
 }

--- a/logic/lib/src/state.dart
+++ b/logic/lib/src/state.dart
@@ -31,6 +31,7 @@ import 'package:logic/src/types/equipment_slot.dart';
 import 'package:logic/src/types/health.dart';
 import 'package:logic/src/types/inventory.dart';
 import 'package:logic/src/types/loot_state.dart';
+import 'package:logic/src/types/modifier_names.dart';
 import 'package:logic/src/types/modifier_provider.dart';
 import 'package:logic/src/types/open_result.dart';
 import 'package:logic/src/types/potion_upgrade_result.dart';
@@ -903,11 +904,30 @@ class GlobalState {
   /// This is the game data used to load the state.
   final Registries registries;
 
-  /// The player's maximum HP (computed from Hitpoints skill level).
+  /// The player's base maximum HP (computed from Hitpoints skill level).
   /// Each Hitpoints level grants 10 HP.
+  ///
+  /// For the modified value that includes equipment bonuses, use
+  /// [maxPlayerHpWithModifiers].
   int get maxPlayerHp {
     final hitpointsLevel = skillState(Skill.hitpoints).skillLevel;
     return hitpointsLevel * 10;
+  }
+
+  /// The player's maximum HP including modifier bonuses.
+  ///
+  /// Applies `maxHitpoints` (percentage) and `flatMaxHitpoints` (flat bonus)
+  /// on top of the base HP from Hitpoints skill level.
+  int maxPlayerHpWithModifiers(ModifierAccessors modifiers) {
+    var hp = maxPlayerHp;
+    // Apply percentage modifier first.
+    final pct = modifiers.maxHitpoints;
+    if (pct != 0) {
+      hp = (hp * (1 + pct / 100)).floor();
+    }
+    // Then apply flat bonus.
+    hp += modifiers.flatMaxHitpoints;
+    return hp.clamp(1, 999999);
   }
 
   /// The player's combat level using Melvor Idle formula.

--- a/logic/lib/src/state_update_builder.dart
+++ b/logic/lib/src/state_update_builder.dart
@@ -492,7 +492,7 @@ class StateUpdateBuilder {
     final threshold = modifiers.autoEatThreshold;
     if (threshold <= 0) return 0;
 
-    final maxHp = _state.maxPlayerHpWithModifiers(modifiers);
+    final maxHp = _state.maxPlayerHp;
     final currentHp = (maxHp - _state.health.lostHp).clamp(0, maxHp);
     final thresholdHp = (maxHp * threshold / 100).ceil();
 

--- a/logic/lib/src/state_update_builder.dart
+++ b/logic/lib/src/state_update_builder.dart
@@ -492,8 +492,8 @@ class StateUpdateBuilder {
     final threshold = modifiers.autoEatThreshold;
     if (threshold <= 0) return 0;
 
-    final maxHp = _state.maxPlayerHp;
-    final currentHp = _state.playerHp;
+    final maxHp = _state.maxPlayerHpWithModifiers(modifiers);
+    final currentHp = (maxHp - _state.health.lostHp).clamp(0, maxHp);
     final thresholdHp = (maxHp * threshold / 100).ceil();
 
     // Check if we're below threshold

--- a/logic/test/combat_stats_test.dart
+++ b/logic/test/combat_stats_test.dart
@@ -1428,7 +1428,7 @@ void main() {
     });
   });
 
-  group('maxPlayerHpWithModifiers', () {
+  group('applyMaxHpModifiers', () {
     test('returns base HP when no modifiers are active', () {
       final state = GlobalState.test(
         testRegistries,
@@ -1437,60 +1437,38 @@ void main() {
         },
       );
       final mods = StubModifierProvider();
-      expect(state.maxPlayerHp, equals(100)); // 10 * 10
-      expect(state.maxPlayerHpWithModifiers(mods), equals(100));
+      expect(state.baseMaxPlayerHp, equals(100)); // 10 * 10
+      // maxPlayerHp equals base when no equipment provides modifiers.
+      expect(state.maxPlayerHp, equals(100));
+      expect(applyMaxHpModifiers(100, mods), equals(100));
     });
 
     test('maxHitpoints percentage modifier increases HP', () {
-      final state = GlobalState.test(
-        testRegistries,
-        skillStates: const {
-          Skill.hitpoints: SkillState(xp: 1154, masteryPoolXp: 0), // Level 10
-        },
-      );
       final mods = StubModifierProvider({'maxHitpoints': 20});
       // 100 * (1 + 20/100) = 120
-      expect(state.maxPlayerHpWithModifiers(mods), equals(120));
+      expect(applyMaxHpModifiers(100, mods), equals(120));
     });
 
     test('flatMaxHitpoints adds flat bonus to HP', () {
-      final state = GlobalState.test(
-        testRegistries,
-        skillStates: const {
-          Skill.hitpoints: SkillState(xp: 1154, masteryPoolXp: 0), // Level 10
-        },
-      );
       final mods = StubModifierProvider({'flatMaxHitpoints': 50});
-      expect(state.maxPlayerHpWithModifiers(mods), equals(150));
+      expect(applyMaxHpModifiers(100, mods), equals(150));
     });
 
     test('both modifiers combine: percentage then flat', () {
-      final state = GlobalState.test(
-        testRegistries,
-        skillStates: const {
-          Skill.hitpoints: SkillState(xp: 1154, masteryPoolXp: 0), // Level 10
-        },
-      );
       final mods = StubModifierProvider({
         'maxHitpoints': 20,
         'flatMaxHitpoints': 50,
       });
       // 100 * 1.2 = 120, then + 50 = 170
-      expect(state.maxPlayerHpWithModifiers(mods), equals(170));
+      expect(applyMaxHpModifiers(100, mods), equals(170));
     });
 
     test('result is clamped to minimum of 1', () {
-      final state = GlobalState.test(
-        testRegistries,
-        skillStates: const {
-          Skill.hitpoints: SkillState(xp: 1154, masteryPoolXp: 0), // Level 10
-        },
-      );
       final mods = StubModifierProvider({
         'maxHitpoints': -100,
         'flatMaxHitpoints': -100,
       });
-      expect(state.maxPlayerHpWithModifiers(mods), equals(1));
+      expect(applyMaxHpModifiers(100, mods), equals(1));
     });
   });
 }

--- a/logic/test/combat_stats_test.dart
+++ b/logic/test/combat_stats_test.dart
@@ -1325,4 +1325,172 @@ void main() {
       expect(statsWithContext.maxHit, statsEmpty.maxHit);
     });
   });
+
+  group('CombatModifierHelpers', () {
+    group('totalDamageDealtModifier', () {
+      test('combines damageDealt and damageDealtToAllMonsters', () {
+        final mods = StubModifierProvider({
+          'damageDealt': 10,
+          'damageDealtToAllMonsters': 5,
+        });
+        expect(
+          mods.totalDamageDealtModifier(
+            isBoss: false,
+            isFightingSlayerTask: false,
+          ),
+          equals(15),
+        );
+      });
+
+      test('includes damageDealtToBosses when fighting a boss', () {
+        final mods = StubModifierProvider({
+          'damageDealt': 10,
+          'damageDealtToAllMonsters': 5,
+          'damageDealtToBosses': 20,
+        });
+        expect(
+          mods.totalDamageDealtModifier(
+            isBoss: true,
+            isFightingSlayerTask: false,
+          ),
+          equals(35),
+        );
+      });
+
+      test('excludes damageDealtToBosses for non-bosses', () {
+        final mods = StubModifierProvider({
+          'damageDealt': 10,
+          'damageDealtToBosses': 20,
+        });
+        expect(
+          mods.totalDamageDealtModifier(
+            isBoss: false,
+            isFightingSlayerTask: false,
+          ),
+          equals(10),
+        );
+      });
+
+      test('includes damageDealtToSlayerTasks on slayer task', () {
+        final mods = StubModifierProvider({
+          'damageDealt': 5,
+          'damageDealtToSlayerTasks': 15,
+        });
+        expect(
+          mods.totalDamageDealtModifier(
+            isBoss: false,
+            isFightingSlayerTask: true,
+          ),
+          equals(20),
+        );
+      });
+
+      test('combines all modifiers for boss slayer task', () {
+        final mods = StubModifierProvider({
+          'damageDealt': 5,
+          'damageDealtToAllMonsters': 3,
+          'damageDealtToBosses': 10,
+          'damageDealtToSlayerTasks': 7,
+        });
+        expect(
+          mods.totalDamageDealtModifier(
+            isBoss: true,
+            isFightingSlayerTask: true,
+          ),
+          equals(25),
+        );
+      });
+    });
+
+    group('applyDamageTakenModifier', () {
+      test('returns unchanged damage when modifier is zero', () {
+        final mods = StubModifierProvider();
+        expect(mods.applyDamageTakenModifier(100), equals(100));
+      });
+
+      test('negative modifier reduces damage taken', () {
+        final mods = StubModifierProvider({'damageTaken': -10});
+        // 100 * (1 + -10/100) = 100 * 0.9 = 90
+        expect(mods.applyDamageTakenModifier(100), equals(90));
+      });
+
+      test('positive modifier increases damage taken', () {
+        final mods = StubModifierProvider({'damageTaken': 20});
+        // 100 * (1 + 20/100) = 100 * 1.2 = 120
+        expect(mods.applyDamageTakenModifier(100), equals(120));
+      });
+
+      test('damage is clamped to zero minimum', () {
+        final mods = StubModifierProvider({'damageTaken': -200});
+        // Would be negative, clamped to 0.
+        expect(mods.applyDamageTakenModifier(100), equals(0));
+      });
+    });
+  });
+
+  group('maxPlayerHpWithModifiers', () {
+    test('returns base HP when no modifiers are active', () {
+      final state = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.hitpoints: SkillState(xp: 1154, masteryPoolXp: 0), // Level 10
+        },
+      );
+      final mods = StubModifierProvider();
+      expect(state.maxPlayerHp, equals(100)); // 10 * 10
+      expect(state.maxPlayerHpWithModifiers(mods), equals(100));
+    });
+
+    test('maxHitpoints percentage modifier increases HP', () {
+      final state = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.hitpoints: SkillState(xp: 1154, masteryPoolXp: 0), // Level 10
+        },
+      );
+      final mods = StubModifierProvider({'maxHitpoints': 20});
+      // 100 * (1 + 20/100) = 120
+      expect(state.maxPlayerHpWithModifiers(mods), equals(120));
+    });
+
+    test('flatMaxHitpoints adds flat bonus to HP', () {
+      final state = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.hitpoints: SkillState(xp: 1154, masteryPoolXp: 0), // Level 10
+        },
+      );
+      final mods = StubModifierProvider({'flatMaxHitpoints': 50});
+      expect(state.maxPlayerHpWithModifiers(mods), equals(150));
+    });
+
+    test('both modifiers combine: percentage then flat', () {
+      final state = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.hitpoints: SkillState(xp: 1154, masteryPoolXp: 0), // Level 10
+        },
+      );
+      final mods = StubModifierProvider({
+        'maxHitpoints': 20,
+        'flatMaxHitpoints': 50,
+      });
+      // 100 * 1.2 = 120, then + 50 = 170
+      expect(state.maxPlayerHpWithModifiers(mods), equals(170));
+    });
+
+    test('result is clamped to minimum of 1', () {
+      final state = GlobalState.test(
+        testRegistries,
+        skillStates: const {
+          Skill.hitpoints: SkillState(xp: 1154, masteryPoolXp: 0), // Level 10
+        },
+      );
+      final mods = StubModifierProvider({
+        'maxHitpoints': -100,
+        'flatMaxHitpoints': -100,
+      });
+      expect(state.maxPlayerHpWithModifiers(mods), equals(1));
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Consume 8 previously-unused combat damage modifiers: `damageDealt`, `damageDealtToAllMonsters`, `damageDealtToBosses`, `damageDealtToSlayerTasks`, `damageTaken`, `maxHitpoints`, `flatMaxHitpoints`, and `maxHit` (already consumed in stats calculation)
- Add `CombatModifierHelpers` extension with `totalDamageDealtModifier()` and `applyDamageTakenModifier()` to avoid code duplication
- Add `maxPlayerHpWithModifiers()` on `GlobalState` for modifier-aware max HP calculation, used in auto-eat thresholds

## Test plan
- [x] Unit tests for `totalDamageDealtModifier` (all combinations: base, boss, slayer task, boss+slayer)
- [x] Unit tests for `applyDamageTakenModifier` (zero, negative, positive, clamp)
- [x] Unit tests for `maxPlayerHpWithModifiers` (none, percentage, flat, combined, clamp)
- [x] All existing tests pass
- [x] `dart analyze --fatal-infos` clean
- [x] `dart format` clean
- [x] `npx cspell` clean

## Related issues
- #260 - `dragonBreathDamage` deferred (requires special attack system)
- #261 - `maxHitpoints` modifiers not yet threaded through all HP call sites