### PR TITLE
feat: show tooltip on disabled buttons explaining why they're dimmed

### DIFF
--- a/logic/lib/src/state.dart
+++ b/logic/lib/src/state.dart
@@ -1109,6 +1109,33 @@ class GlobalState {
     return true;
   }
 
+  /// Returns a human-readable reason why the action cannot be started,
+  /// or null if the action can be started.
+  String? cannotStartReason(Action action) {
+    if (action is SkillAction) {
+      final inputs = effectiveInputs(action);
+
+      // Check inputs
+      for (final requirement in inputs.entries) {
+        final item = registries.items.byId(requirement.key);
+        final itemCount = inventory.countOfItem(item);
+        if (itemCount < requirement.value) {
+          return 'Need ${requirement.value} ${item.name}'
+              ' (have $itemCount)';
+        }
+      }
+
+      // Check if summoning action requires marks
+      if (action is SummoningAction) {
+        if (!summoning.canCraftTablet(action.productId)) {
+          return 'Need at least 1 mark to craft tablets';
+        }
+      }
+    }
+
+    return null;
+  }
+
   /// Returns the shop duration modifier for a skill as a decimal fraction.
   /// For example, -0.05 means 5% reduction.
   /// This is a convenience method that combines ShopState and ShopRegistry.

--- a/logic/test/state_test.dart
+++ b/logic/test/state_test.dart
@@ -2629,4 +2629,39 @@ void main() {
       expect(result.gp, lessThan(state.gp));
     });
   });
+
+  group('cannotStartReason', () {
+    late SkillAction bronzeBar;
+
+    setUpAll(() {
+      bronzeBar = testRegistries.smithingAction('Bronze Bar');
+    });
+
+    test('returns null when all inputs are available', () {
+      final copperOre = testItems.byName('Copper Ore');
+      final tinOre = testItems.byName('Tin Ore');
+      final state = GlobalState.test(
+        testRegistries,
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(copperOre, count: 1),
+          ItemStack(tinOre, count: 1),
+        ]),
+      );
+      expect(state.cannotStartReason(bronzeBar), isNull);
+    });
+
+    test('returns reason when missing an input', () {
+      final state = GlobalState.test(testRegistries);
+      final reason = state.cannotStartReason(bronzeBar);
+      expect(reason, isNotNull);
+      expect(reason, contains('Need'));
+      expect(reason, contains('have 0'));
+    });
+
+    test('returns null for combat actions', () {
+      final cow = testRegistries.combatAction('Cow');
+      final state = GlobalState.test(testRegistries);
+      expect(state.cannotStartReason(cow), isNull);
+    });
+  });
 }

--- a/ui/lib/src/screens/farming.dart
+++ b/ui/lib/src/screens/farming.dart
@@ -3,6 +3,7 @@ import 'package:logic/logic.dart';
 import 'package:ui/src/logic/redux_actions.dart';
 import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/cost_row.dart';
+import 'package:ui/src/widgets/disabled_button_tooltip.dart';
 import 'package:ui/src/widgets/game_scaffold.dart';
 import 'package:ui/src/widgets/item_count_badge_cell.dart';
 import 'package:ui/src/widgets/item_image.dart';
@@ -166,28 +167,42 @@ class _CategorySection extends StatelessWidget {
                 style: Theme.of(context).textTheme.titleLarge,
               ),
               const Spacer(),
-              FilledButton.tonal(
-                onPressed: readyCount > 0 && canAffordHarvest
-                    ? () => context.dispatch(
-                        HarvestAllCropsAction(categoryId: category.id),
-                      )
+              DisabledButtonTooltip(
+                message: readyCount == 0
+                    ? 'No crops ready to harvest'
+                    : !canAffordHarvest
+                    ? 'Not enough GP'
                     : null,
-                child: Text('Harvest All ($readyCount)'),
+                child: FilledButton.tonal(
+                  onPressed: readyCount > 0 && canAffordHarvest
+                      ? () => context.dispatch(
+                          HarvestAllCropsAction(categoryId: category.id),
+                        )
+                      : null,
+                  child: Text('Harvest All ($readyCount)'),
+                ),
               ),
               const SizedBox(width: 8),
-              FilledButton.tonal(
-                onPressed: emptyCount > 0 && canAffordPlant
-                    ? () => showDialog<void>(
-                        context: context,
-                        builder: (dialogContext) => _PlantAllDialog(
-                          category: category,
-                          state: state,
-                          emptyCount: emptyCount,
-                          outerContext: context,
-                        ),
-                      )
+              DisabledButtonTooltip(
+                message: emptyCount == 0
+                    ? 'No empty plots'
+                    : !canAffordPlant
+                    ? 'Not enough GP'
                     : null,
-                child: Text('Plant All ($emptyCount)'),
+                child: FilledButton.tonal(
+                  onPressed: emptyCount > 0 && canAffordPlant
+                      ? () => showDialog<void>(
+                          context: context,
+                          builder: (dialogContext) => _PlantAllDialog(
+                            category: category,
+                            state: state,
+                            emptyCount: emptyCount,
+                            outerContext: context,
+                          ),
+                        )
+                      : null,
+                  child: Text('Plant All ($emptyCount)'),
+                ),
               ),
             ],
           ),

--- a/ui/lib/src/widgets/disabled_button_tooltip.dart
+++ b/ui/lib/src/widgets/disabled_button_tooltip.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// Wraps a button and shows a tooltip explaining why it's disabled.
+///
+/// When [message] is non-null, the child is wrapped in [IgnorePointer]
+/// (so the disabled button doesn't eat the tap) and a [Tooltip] that
+/// triggers on tap. When [message] is null, the child is returned as-is.
+class DisabledButtonTooltip extends StatelessWidget {
+  const DisabledButtonTooltip({
+    required this.message,
+    required this.child,
+    super.key,
+  });
+
+  /// The tooltip message to show, or null if the button is enabled.
+  final String? message;
+
+  /// The button widget to wrap.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (message == null) return child;
+    return Tooltip(
+      message: message,
+      triggerMode: TooltipTriggerMode.tap,
+      child: IgnorePointer(child: child),
+    );
+  }
+}

--- a/ui/lib/src/widgets/production_action_display.dart
+++ b/ui/lib/src/widgets/production_action_display.dart
@@ -5,6 +5,7 @@ import 'package:ui/src/widgets/action_grid.dart';
 import 'package:ui/src/widgets/cached_image.dart';
 import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/count_badge_cell.dart';
+import 'package:ui/src/widgets/disabled_button_tooltip.dart';
 import 'package:ui/src/widgets/double_chance_badge_cell.dart';
 import 'package:ui/src/widgets/duration_badge_cell.dart';
 import 'package:ui/src/widgets/item_count_badge_cell.dart';
@@ -361,12 +362,17 @@ class ProductionActionDisplay extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        ElevatedButton(
-          onPressed: canStart || isActive ? onStart : null,
-          style: ElevatedButton.styleFrom(
-            backgroundColor: isActive ? Style.activeColor : null,
+        DisabledButtonTooltip(
+          message: !canStart && !isActive
+              ? state.cannotStartReason(action)
+              : null,
+          child: ElevatedButton(
+            onPressed: canStart || isActive ? onStart : null,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: isActive ? Style.activeColor : null,
+            ),
+            child: Text(isActive ? 'Stop' : buttonText),
           ),
-          child: Text(isActive ? 'Stop' : buttonText),
         ),
         const SizedBox(width: 16),
         DurationBadgeCell(seconds: modifiedSeconds),

--- a/ui/lib/src/widgets/skill_action_display.dart
+++ b/ui/lib/src/widgets/skill_action_display.dart
@@ -4,6 +4,7 @@ import 'package:ui/src/logic/redux_actions.dart';
 import 'package:ui/src/widgets/cached_image.dart';
 import 'package:ui/src/widgets/context_extensions.dart';
 import 'package:ui/src/widgets/count_badge_cell.dart';
+import 'package:ui/src/widgets/disabled_button_tooltip.dart';
 import 'package:ui/src/widgets/double_chance_badge_cell.dart';
 import 'package:ui/src/widgets/item_count_badge_cell.dart';
 import 'package:ui/src/widgets/mastery_pool.dart';
@@ -307,12 +308,17 @@ class SkillActionDisplay extends StatelessWidget {
           const SizedBox(height: 8),
 
           // Action button
-          ElevatedButton(
-            onPressed: canStart || isActive ? onStart : null,
-            style: ElevatedButton.styleFrom(
-              backgroundColor: isActive ? Style.activeColor : null,
+          DisabledButtonTooltip(
+            message: !canStart && !isActive
+                ? state.cannotStartReason(action)
+                : null,
+            child: ElevatedButton(
+              onPressed: canStart || isActive ? onStart : null,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: isActive ? Style.activeColor : null,
+              ),
+              child: Text(isActive ? 'Stop' : buttonText),
             ),
-            child: Text(isActive ? 'Stop' : buttonText),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- Added `cannotStartReason(Action)` to `GlobalState` that returns a human-readable reason why an action can't start (missing items, summoning marks)
- Created `DisabledButtonTooltip` widget that shows a tap-triggered tooltip when a button is disabled
- Applied to farming (Harvest All / Plant All), `SkillActionDisplay`, and `ProductionActionDisplay` start buttons

## Test plan
- [ ] Verify tapping a dimmed Harvest All button shows "No crops ready to harvest" or "Not enough GP"
- [ ] Verify tapping a dimmed Plant All button shows "No empty plots" or "Not enough GP"
- [ ] Verify tapping a dimmed Start button in smithing/cooking/etc shows the missing input (e.g. "Need 1 Copper Ore (have 0)")
- [ ] Verify enabled buttons still work normally with no tooltip
- [ ] `dart test` passes in logic/