### PR TITLE
fix: show shop description for Warm Beanie, move description logic to logic layer

### DIFF
--- a/logic/lib/src/data/shop.dart
+++ b/logic/lib/src/data/shop.dart
@@ -6,6 +6,7 @@ import 'package:logic/src/data/currency.dart';
 import 'package:logic/src/data/melvor_id.dart';
 import 'package:logic/src/state.dart';
 import 'package:logic/src/types/modifier.dart';
+import 'package:logic/src/types/modifier_metadata.dart';
 import 'package:meta/meta.dart';
 
 /// An item cost for a shop purchase.
@@ -565,6 +566,74 @@ class ShopPurchase extends Equatable {
   /// Whether this purchase has skill interval modifiers for the given skill.
   bool hasSkillIntervalFor(MelvorId skillId) =>
       contains.modifiers.hasSkillIntervalFor(skillId);
+
+  /// Returns a description string suitable for displaying in the shop.
+  ///
+  /// Resolves the description from (in priority order):
+  /// 1. Custom description (with template variables substituted)
+  /// 2. Item charges description
+  /// 3. Purchase modifier descriptions (skill interval, bank space)
+  /// 4. Contained item's custom description
+  /// 5. Contained item's modifier descriptions
+  ///
+  /// Returns null if no description can be generated.
+  String? shopDescription(
+    ItemRegistry items,
+    ModifierMetadataRegistry modifierMetadata,
+  ) {
+    // Prefer custom description if available
+    if (description != null) {
+      return _substituteTemplateVars(description!);
+    }
+
+    // Handle itemCharges purchases
+    final itemCharges = contains.itemCharges;
+    if (itemCharges != null) {
+      final item = items.byId(itemCharges.itemId);
+      final chargeCount = itemCharges.quantity;
+      final itemDescription = item.description ?? item.name;
+      return '+$chargeCount charges: $itemDescription';
+    }
+
+    // Build description from purchase modifiers
+    final parts = <String>[];
+    final modifiers = contains.modifiers;
+    for (final skillId in modifiers.skillIntervalSkillIds) {
+      final skill = Skill.fromId(skillId);
+      final value = modifiers.skillIntervalForSkill(skillId);
+      final percent = value < 0 ? '$value%' : '+$value%';
+      parts.add('$percent ${skill.name} time');
+    }
+    final bankSpace = contains.bankSpace;
+    if (bankSpace != null) {
+      parts.add('+$bankSpace bank space');
+    }
+    if (parts.isNotEmpty) return parts.join(', ');
+
+    // Fall back to contained item's description or modifiers
+    if (contains.items.length == 1) {
+      final item = items.byId(contains.items.first.itemId);
+      if (item.description != null) return item.description;
+      if (item.modifiers.modifiers.isNotEmpty) {
+        final descs = modifierMetadata.formatModifierDescriptions(
+          item.modifiers,
+        );
+        if (descs.isNotEmpty) return descs.join(', ');
+      }
+    }
+
+    return null;
+  }
+
+  /// Substitutes template variables like ${qty}, ${qty1}, etc.
+  String _substituteTemplateVars(String text) {
+    var result = text.replaceAll(r'${qty}', '1');
+    for (var i = 0; i < contains.items.length; i++) {
+      final quantity = contains.items[i].quantity;
+      result = result.replaceAll('\${qty${i + 1}}', quantity.toString());
+    }
+    return result;
+  }
 
   @override
   List<Object?> get props => [

--- a/logic/lib/src/types/modifier_metadata.dart
+++ b/logic/lib/src/types/modifier_metadata.dart
@@ -1,5 +1,8 @@
 import 'package:equatable/equatable.dart';
+import 'package:logic/src/data/actions.dart';
+import 'package:logic/src/data/currency.dart';
 import 'package:logic/src/strings.dart';
+import 'package:logic/src/types/modifier.dart';
 import 'package:meta/meta.dart';
 
 /// A single description template for a modifier value.
@@ -433,6 +436,36 @@ class ModifierMetadataRegistry {
     }
     // Most modifiers are percentages
     return '$sign$absValue%';
+  }
+
+  /// Formats all modifiers in a [ModifierDataSet] into human-readable
+  /// descriptions, resolving skill and currency names from scopes.
+  List<String> formatModifierDescriptions(ModifierDataSet modifiers) {
+    final descriptions = <String>[];
+    for (final mod in modifiers.modifiers) {
+      for (final entry in mod.entries) {
+        String? skillName;
+        String? currencyName;
+        final scope = entry.scope;
+        if (scope != null) {
+          if (scope.skillId != null) {
+            skillName = Skill.fromId(scope.skillId!).name;
+          }
+          if (scope.currencyId != null) {
+            currencyName = Currency.fromId(scope.currencyId!).name;
+          }
+        }
+        descriptions.add(
+          formatDescription(
+            name: mod.name,
+            value: entry.value,
+            skillName: skillName,
+            currencyName: currencyName,
+          ),
+        );
+      }
+    }
+    return descriptions;
   }
 
   /// Generic fallback formatting based on modifier name patterns.

--- a/logic/test/data/shop_test.dart
+++ b/logic/test/data/shop_test.dart
@@ -236,6 +236,157 @@ void main() {
     });
   });
 
+  group('ShopPurchase.shopDescription', () {
+    setUpAll(() async {
+      await loadTestRegistries();
+    });
+
+    ShopPurchase makePurchase({
+      String? description,
+      ModifierDataSet modifiers = const ModifierDataSet([]),
+      List<ItemCost> items = const [],
+      ItemCost? itemCharges,
+    }) {
+      return ShopPurchase(
+        id: const MelvorId('melvorD:Test'),
+        name: 'Test',
+        description: description,
+        category: const MelvorId('melvorD:General'),
+        cost: const ShopCost(currencies: [], items: []),
+        unlockRequirements: const [],
+        purchaseRequirements: const [],
+        contains: ShopContents(
+          modifiers: modifiers,
+          items: items,
+          itemCharges: itemCharges,
+        ),
+        buyLimit: 1,
+      );
+    }
+
+    test('returns custom description with template vars substituted', () {
+      final purchase = makePurchase(
+        description: r'Grants +${qty1} arrows and +${qty2} bolts',
+        items: [
+          const ItemCost(
+            itemId: MelvorId('melvorD:Bronze_Arrows'),
+            quantity: 200,
+          ),
+          const ItemCost(
+            itemId: MelvorId('melvorD:Bronze_Bolts'),
+            quantity: 150,
+          ),
+        ],
+      );
+
+      final desc = purchase.shopDescription(
+        testRegistries.items,
+        testRegistries.modifierMetadata,
+      );
+      expect(desc, 'Grants +200 arrows and +150 bolts');
+    });
+
+    test('returns itemCharges description', () {
+      // Find a real itemCharges purchase from the registry
+      final chargesPurchase = testRegistries.shop.all.firstWhere(
+        (p) => p.contains.itemCharges != null,
+      );
+      final desc = chargesPurchase.shopDescription(
+        testRegistries.items,
+        testRegistries.modifierMetadata,
+      );
+      expect(desc, isNotNull);
+      expect(desc, contains('charges'));
+    });
+
+    test('returns skill interval description from purchase modifiers', () {
+      final modifiers = ModifierDataSet.fromJson(const {
+        'skillInterval': [
+          {'skillID': 'melvorD:Woodcutting', 'value': -5},
+        ],
+      }, namespace: 'melvorD');
+      final purchase = makePurchase(modifiers: modifiers);
+
+      final desc = purchase.shopDescription(
+        testRegistries.items,
+        testRegistries.modifierMetadata,
+      );
+      expect(desc, '-5% Woodcutting time');
+    });
+
+    test('returns bank space description', () {
+      final modifiers = ModifierDataSet.fromJson(const {
+        'bankSpace': 10,
+      }, namespace: 'melvorD');
+      final purchase = makePurchase(modifiers: modifiers);
+
+      final desc = purchase.shopDescription(
+        testRegistries.items,
+        testRegistries.modifierMetadata,
+      );
+      expect(desc, '+10 bank space');
+    });
+
+    test('returns item description for single contained item', () {
+      // Find an item with a description
+      final itemWithDesc = testRegistries.items.all.firstWhere(
+        (i) => i.description != null,
+      );
+      final purchase = makePurchase(
+        items: [ItemCost(itemId: itemWithDesc.id, quantity: 1)],
+      );
+
+      final desc = purchase.shopDescription(
+        testRegistries.items,
+        testRegistries.modifierMetadata,
+      );
+      expect(desc, itemWithDesc.description);
+    });
+
+    test('returns modifier descriptions for single item with modifiers', () {
+      // Find an item with modifiers but no description
+      final itemWithMods = testRegistries.items.all.firstWhere(
+        (i) => i.description == null && i.modifiers.modifiers.isNotEmpty,
+      );
+      final purchase = makePurchase(
+        items: [ItemCost(itemId: itemWithMods.id, quantity: 1)],
+      );
+
+      final desc = purchase.shopDescription(
+        testRegistries.items,
+        testRegistries.modifierMetadata,
+      );
+      expect(desc, isNotNull);
+      expect(desc, isNotEmpty);
+    });
+
+    test('returns null when no description can be generated', () {
+      final purchase = makePurchase();
+
+      final desc = purchase.shopDescription(
+        testRegistries.items,
+        testRegistries.modifierMetadata,
+      );
+      expect(desc, isNull);
+    });
+
+    test('custom description takes priority over modifiers', () {
+      final modifiers = ModifierDataSet.fromJson(const {
+        'bankSpace': 10,
+      }, namespace: 'melvorD');
+      final purchase = makePurchase(
+        description: 'Custom text',
+        modifiers: modifiers,
+      );
+
+      final desc = purchase.shopDescription(
+        testRegistries.items,
+        testRegistries.modifierMetadata,
+      );
+      expect(desc, 'Custom text');
+    });
+  });
+
   group('ShopCategory', () {
     test('fromJson parses correctly', () {
       final json = {

--- a/logic/test/types/modifier_metadata_test.dart
+++ b/logic/test/types/modifier_metadata_test.dart
@@ -1,3 +1,4 @@
+import 'package:logic/src/types/modifier.dart';
 import 'package:logic/src/types/modifier_metadata.dart';
 import 'package:test/test.dart';
 
@@ -494,6 +495,53 @@ void main() {
       expect(scopeDef.matchesScopes(hasSkill: true), isFalse);
       expect(scopeDef.matchesScopes(hasAction: true), isFalse);
       expect(scopeDef.matchesScopes(hasSkill: true, hasAction: true), isTrue);
+    });
+  });
+
+  group('ModifierMetadataRegistry.formatModifierDescriptions', () {
+    test('returns empty list for empty modifier set', () {
+      const registry = ModifierMetadataRegistry.empty();
+      const modifiers = ModifierDataSet([]);
+      expect(registry.formatModifierDescriptions(modifiers), isEmpty);
+    });
+
+    test('formats scalar modifier', () {
+      const registry = ModifierMetadataRegistry.empty();
+      final modifiers = ModifierDataSet.fromJson(const {
+        'bankSpace': 10,
+      }, namespace: 'melvorD');
+      final descriptions = registry.formatModifierDescriptions(modifiers);
+      expect(descriptions, hasLength(1));
+      expect(descriptions.first, contains('10'));
+    });
+
+    test('formats skill-scoped modifier with skill name', () {
+      const registry = ModifierMetadataRegistry.empty();
+      final modifiers = ModifierDataSet.fromJson(const {
+        'skillInterval': [
+          {'skillID': 'melvorD:Woodcutting', 'value': -5},
+        ],
+      }, namespace: 'melvorD');
+      final descriptions = registry.formatModifierDescriptions(modifiers);
+      expect(descriptions, hasLength(1));
+      expect(descriptions.first, contains('Woodcutting'));
+    });
+
+    test('formats multiple modifiers with multiple entries', () {
+      const registry = ModifierMetadataRegistry.empty();
+      final modifiers = ModifierDataSet.fromJson(const {
+        'skillItemDoublingChance': [
+          {'skillID': 'melvorD:Firemaking', 'value': 2},
+        ],
+        'masteryXP': [
+          {'skillID': 'melvorD:Firemaking', 'value': 3},
+        ],
+        'skillInterval': [
+          {'skillID': 'melvorD:Firemaking', 'value': -2},
+        ],
+      }, namespace: 'melvorD');
+      final descriptions = registry.formatModifierDescriptions(modifiers);
+      expect(descriptions, hasLength(3));
     });
   });
 }

--- a/ui/lib/src/screens/bank.dart
+++ b/ui/lib/src/screens/bank.dart
@@ -1788,7 +1788,7 @@ class _ItemModifiersDisplay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final registry = context.state.registries.modifierMetadata;
-    final descriptions = _formatModifiers(item, registry);
+    final descriptions = registry.formatModifierDescriptions(item.modifiers);
 
     if (descriptions.isEmpty) return const SizedBox.shrink();
 
@@ -1809,35 +1809,4 @@ class _ItemModifiersDisplay extends StatelessWidget {
     );
   }
 
-  List<String> _formatModifiers(Item item, ModifierMetadataRegistry registry) {
-    final descriptions = <String>[];
-
-    for (final mod in item.modifiers.modifiers) {
-      for (final entry in mod.entries) {
-        // Extract scope information for formatting
-        String? skillName;
-        String? currencyName;
-        final scope = entry.scope;
-        if (scope != null) {
-          if (scope.skillId != null) {
-            skillName = Skill.fromId(scope.skillId!).name;
-          }
-          if (scope.currencyId != null) {
-            currencyName = Currency.fromId(scope.currencyId!).name;
-          }
-        }
-
-        descriptions.add(
-          registry.formatDescription(
-            name: mod.name,
-            value: entry.value,
-            skillName: skillName,
-            currencyName: currencyName,
-          ),
-        );
-      }
-    }
-
-    return descriptions;
-  }
 }

--- a/ui/lib/src/screens/shop.dart
+++ b/ui/lib/src/screens/shop.dart
@@ -261,52 +261,17 @@ class _ShopPageState extends State<ShopPage> {
     ShopPurchase purchase,
     ShopViewModel viewModel,
   ) {
-    // Prefer custom description if available
-    // (e.g., Magic Pot has detailed modifier info)
+    final text = purchase.shopDescription(
+      viewModel._state.registries.items,
+      viewModel._state.registries.modifierMetadata,
+    );
+    if (text == null) return null;
+
+    // Custom descriptions may contain HTML markup (e.g., <br>, <span>).
     if (purchase.description != null) {
-      return _parseDescription(purchase.description!, purchase: purchase);
+      return _parseDescription(text);
     }
-
-    // Handle itemCharges purchases
-    final itemCharges = purchase.contains.itemCharges;
-    if (itemCharges != null) {
-      final item = viewModel.itemById(itemCharges.itemId);
-      final chargeCount = itemCharges.quantity;
-      final itemDescription = item.description ?? item.name;
-
-      return TextSpan(text: '+$chargeCount charges: $itemDescription');
-    }
-
-    // Otherwise build description from modifiers we understand
-    final parts = <String>[];
-
-    // Add skill interval modifiers
-    final modifiers = purchase.contains.modifiers;
-    for (final skillId in modifiers.skillIntervalSkillIds) {
-      final skill = Skill.fromId(skillId);
-      final value = modifiers.skillIntervalForSkill(skillId);
-      final percent = value < 0 ? '$value%' : '+$value%';
-      parts.add('$percent ${skill.name} time');
-    }
-
-    // Add bank space
-    final bankSpace = purchase.contains.bankSpace;
-    if (bankSpace != null) {
-      parts.add('+$bankSpace bank space');
-    }
-
-    // If no auto-generated description, check if purchase contains a single
-    // item with a custom description (e.g., Feathers)
-    if (parts.isEmpty && purchase.contains.items.length == 1) {
-      final itemId = purchase.contains.items.first.itemId;
-      final item = viewModel.itemById(itemId);
-      if (item.description != null) {
-        return _parseDescription(item.description!);
-      }
-    }
-
-    if (parts.isEmpty) return null;
-    return TextSpan(text: parts.join(', '));
+    return TextSpan(text: text);
   }
 
   void _showBulkPurchaseDialog(

--- a/ui/lib/src/widgets/equipment_stats_dialog.dart
+++ b/ui/lib/src/widgets/equipment_stats_dialog.dart
@@ -71,7 +71,8 @@ class _ItemInfoCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final registry = context.state.registries.modifierMetadata;
-    final modifierDescriptions = _formatModifiers(item, registry);
+    final modifierDescriptions =
+        registry.formatModifierDescriptions(item.modifiers);
 
     return SizedBox(
       width: 180,
@@ -113,33 +114,6 @@ class _ItemInfoCard extends StatelessWidget {
     );
   }
 
-  List<String> _formatModifiers(Item item, ModifierMetadataRegistry registry) {
-    final descriptions = <String>[];
-    for (final mod in item.modifiers.modifiers) {
-      for (final entry in mod.entries) {
-        String? skillName;
-        String? currencyName;
-        final scope = entry.scope;
-        if (scope != null) {
-          if (scope.skillId != null) {
-            skillName = Skill.fromId(scope.skillId!).name;
-          }
-          if (scope.currencyId != null) {
-            currencyName = Currency.fromId(scope.currencyId!).name;
-          }
-        }
-        descriptions.add(
-          registry.formatDescription(
-            name: mod.name,
-            value: entry.value,
-            skillName: skillName,
-            currencyName: currencyName,
-          ),
-        );
-      }
-    }
-    return descriptions;
-  }
 }
 
 class _StatsCard extends StatelessWidget {


### PR DESCRIPTION
## Summary
- Shop purchases containing equipment items with modifiers (e.g., Warm Beanie) were showing no description text
- Moved all shop description generation from UI into `ShopPurchase.shopDescription()` in the logic layer, resolving descriptions via a priority chain: custom description → item charges → purchase modifiers → item description → item modifier descriptions
- Consolidated the duplicated `_formatModifiers(Item, Registry)` pattern (copy-pasted in bank.dart, equipment_stats_dialog.dart) into `ModifierMetadataRegistry.formatModifierDescriptions()`

## Test plan
- [x] Added 8 tests for `ShopPurchase.shopDescription` covering all priority levels and edge cases
- [x] Added 3 tests for `ModifierMetadataRegistry.formatModifierDescriptions`
- [x] All logic tests pass (2390)
- [x] All UI tests pass (175)
- [x] `dart analyze --fatal-infos` clean on all changed files