### PR TITLE
ci: add per-package CI with path filters

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Dependabot auto-updates action versions in your workflows.
+# https://docs.github.com/en/code-security/dependabot
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      gha-deps:
+        patterns:
+          - "*"

--- a/.github/workflows/_shorebird_ci_dart.yaml
+++ b/.github/workflows/_shorebird_ci_dart.yaml
@@ -1,0 +1,55 @@
+# Reusable workflow: CI steps for a single Dart package.
+on:
+  workflow_call:
+    inputs:
+      package_name:
+        required: true
+        type: string
+      package_path:
+        required: true
+        type: string
+      has_bloc_lint:
+        required: false
+        default: false
+        type: boolean
+      subpackages:
+        required: false
+        default: ""
+        type: string
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - uses: dart-lang/setup-dart@v1
+      - name: Setup Bloc Tools
+        if: inputs.has_bloc_lint
+        uses: felangel/setup-bloc-tools@v0
+      - name: Install Dependencies
+        working-directory: ${{ inputs.package_path }}
+        run: |
+          dart pub get --no-example
+          for sub in ${{ inputs.subpackages }}; do
+            dart pub get --no-example -C $sub
+          done
+      - working-directory: ${{ inputs.package_path }}
+        run: dart format --set-exit-if-changed .
+      - working-directory: ${{ inputs.package_path }}
+        run: dart analyze .
+      - name: Bloc Lint
+        if: inputs.has_bloc_lint
+        working-directory: ${{ inputs.package_path }}
+        run: bloc lint .
+      - name: Run Tests
+        working-directory: ${{ inputs.package_path }}
+        run: |
+          dart pub global activate coverage && \
+          dart test --coverage=coverage && \
+          dart pub global run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib --check-ignore
+      - uses: codecov/codecov-action@v6
+        with:
+          flags: ${{ inputs.package_name }}
+          working-directory: ${{ inputs.package_path }}

--- a/.github/workflows/_shorebird_ci_flutter.yaml
+++ b/.github/workflows/_shorebird_ci_flutter.yaml
@@ -1,0 +1,67 @@
+# Reusable workflow: CI steps for a single Flutter package.
+on:
+  workflow_call:
+    inputs:
+      package_name:
+        required: true
+        type: string
+      package_path:
+        required: true
+        type: string
+      flutter_version:
+        required: false
+        default: ""
+        type: string
+      has_bloc_lint:
+        required: false
+        default: false
+        type: boolean
+      has_integration_tests:
+        required: false
+        default: false
+        type: boolean
+      subpackages:
+        required: false
+        default: ""
+        type: string
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ inputs.flutter_version || '' }}
+          channel: ${{ inputs.flutter_version && '' || 'stable' }}
+      - name: Setup Bloc Tools
+        if: inputs.has_bloc_lint
+        uses: felangel/setup-bloc-tools@v0
+      - name: Install Dependencies
+        working-directory: ${{ inputs.package_path }}
+        run: |
+          flutter pub get --no-example
+          for sub in ${{ inputs.subpackages }}; do
+            flutter pub get --no-example -C $sub
+          done
+      - working-directory: ${{ inputs.package_path }}
+        run: dart format --set-exit-if-changed .
+      - working-directory: ${{ inputs.package_path }}
+        run: flutter analyze .
+      - name: Bloc Lint
+        if: inputs.has_bloc_lint
+        working-directory: ${{ inputs.package_path }}
+        run: bloc lint .
+      - working-directory: ${{ inputs.package_path }}
+        run: flutter test --coverage
+      - uses: codecov/codecov-action@v6
+        with:
+          flags: ${{ inputs.package_name }}
+          working-directory: ${{ inputs.package_path }}
+      - name: Integration Tests
+        if: inputs.has_integration_tests
+        working-directory: ${{ inputs.package_path }}
+        run: flutter test integration_test

--- a/.github/workflows/shorebird_ci.yaml
+++ b/.github/workflows/shorebird_ci.yaml
@@ -1,0 +1,74 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      ccov: ${{ steps.filter.outputs.ccov }}
+      logic: ${{ steps.filter.outputs.logic }}
+      ui: ${{ steps.filter.outputs.ui }}
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            ccov:
+              - ccov/**
+            logic:
+              - logic/**
+            ui:
+              - logic/**
+              - ui/**
+
+  ccov:
+    needs: changes
+    if: needs.changes.outputs.ccov == 'true'
+    uses: ./.github/workflows/_shorebird_ci_dart.yaml
+    with:
+      package_name: ccov
+      package_path: ccov
+      has_bloc_lint: false
+      subpackages: ""
+
+  logic:
+    needs: changes
+    if: needs.changes.outputs.logic == 'true'
+    uses: ./.github/workflows/_shorebird_ci_dart.yaml
+    with:
+      package_name: logic
+      package_path: logic
+      has_bloc_lint: false
+      subpackages: ""
+
+  ui:
+    needs: changes
+    if: needs.changes.outputs.ui == 'true'
+    uses: ./.github/workflows/_shorebird_ci_flutter.yaml
+    with:
+      package_name: ui
+      package_path: ui
+      has_bloc_lint: false
+      subpackages: ""
+      flutter_version: ""
+      has_integration_tests: false
+
+  cspell:
+    name: CSpell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - uses: streetsidesoftware/cspell-action@v8
+        with:
+          incremental_files_only: false
+          config: cspell.config.yaml
+


### PR DESCRIPTION
## Summary

Experimenting with a CI setup that only runs work for packages affected by a PR.

- `changes` job uses `dorny/paths-filter` to detect which of `ccov`, `logic`, `ui` changed (including transitive deps)
- Per-package jobs fan out from there, gated on the dorny outputs
- Per-package jobs use reusable workflows (`_shorebird_ci_dart.yaml` and `_shorebird_ci_flutter.yaml`) so the step definitions aren't duplicated
- Also adds `.github/dependabot.yml` for github-actions version bumps

## Test plan

- [ ] PR touching only `ccov/**` → only the `ccov` job runs
- [ ] PR touching only `logic/**` → both `logic` and `ui` run (ui depends on logic)
- [ ] PR touching only `ui/**` → only `ui` runs
- [ ] PR touching only docs → no package jobs run
- [ ] CSpell job runs on every PR