### PR TITLE
feat: charge currency cost when crafting summoning tablets

### DIFF
--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -1167,9 +1167,13 @@ bool completeAction(
   _rollMarkDiscovery(builder, action, random);
 
   // Mark tablet as crafted when completing a summoning action
-  // This unblocks further mark discovery for that familiar
+  // This unblocks further mark discovery for that familiar.
+  // Currency costs (e.g. GP) are charged regardless of preservation.
   if (action is SummoningAction) {
     builder.markTabletCrafted(action.productId);
+    for (final cost in action.currencyCosts.costs) {
+      builder.addCurrency(cost.currency, -cost.amount);
+    }
   }
 
   // Apply mining swing damage/depletion. Depletion does not short-circuit

--- a/logic/lib/src/data/summoning.dart
+++ b/logic/lib/src/data/summoning.dart
@@ -1,5 +1,6 @@
 import 'package:logic/src/data/action_id.dart';
 import 'package:logic/src/data/actions.dart';
+import 'package:logic/src/data/currency.dart';
 import 'package:logic/src/data/melvor_id.dart';
 import 'package:meta/meta.dart';
 
@@ -23,6 +24,7 @@ class SummoningAction extends SkillAction {
     required this.tier,
     required this.markMedia,
     required this.markSkillIds,
+    this.currencyCosts = CurrencyCosts.empty,
     super.alternativeRecipes,
   }) : super(skill: Skill.summoning, duration: _summoningDuration);
 
@@ -94,6 +96,10 @@ class SummoningAction extends SkillAction {
         ? alternativeRecipes.first.inputs
         : shardInputs;
 
+    final currencyCosts = CurrencyCosts.fromJson(
+      json['currencyCosts'] as List<dynamic>?,
+    );
+
     return SummoningAction(
       id: ActionId(Skill.summoning.id, localId),
       name: productId.name,
@@ -106,6 +112,7 @@ class SummoningAction extends SkillAction {
       tier: tier,
       markMedia: json['markMedia'] as String?,
       markSkillIds: markSkillIds,
+      currencyCosts: currencyCosts,
     );
   }
 
@@ -122,6 +129,10 @@ class SummoningAction extends SkillAction {
   /// When performing actions in these skills, players have a chance to
   /// discover marks for this familiar.
   final List<MelvorId> markSkillIds;
+
+  /// Currency costs (e.g., GP) charged each time a tablet is crafted.
+  /// Charged regardless of preservation rolls.
+  final CurrencyCosts currencyCosts;
 
   /// The summon/recipe ID for this familiar (e.g., "melvorF:GolbinThief").
   /// This is used for synergy lookups.

--- a/logic/lib/src/state.dart
+++ b/logic/lib/src/state.dart
@@ -1097,10 +1097,13 @@ class GlobalState {
         }
       }
 
-      // Check if summoning action requires marks
+      // Check if summoning action requires marks and has affordable currency.
       if (action is SummoningAction) {
         if (!summoning.canCraftTablet(action.productId)) {
           return false; // Need at least 1 mark to craft tablets
+        }
+        for (final cost in action.currencyCosts.costs) {
+          if (currency(cost.currency) < cost.amount) return false;
         }
       }
     }

--- a/logic/test/summoning_state_test.dart
+++ b/logic/test/summoning_state_test.dart
@@ -107,6 +107,51 @@ void main() {
       expect(recipe.inputs[logsId], 6);
       expect(action.tier, 1);
     });
+
+    test('parses currencyCosts (e.g. Leprechaun GP cost)', () {
+      final json = {
+        'id': 'Leprechaun',
+        'level': 45,
+        'productID': 'melvorF:Summoning_Familiar_Leprechaun',
+        'baseQuantity': 25,
+        'baseExperience': 23,
+        'itemCosts': [
+          {'id': 'melvorF:Summoning_Shard_Green', 'quantity': 8},
+        ],
+        'nonShardItemCosts': <String>[],
+        'tier': 2,
+        'skillIDs': ['melvorD:Thieving'],
+        'currencyCosts': [
+          {'id': 'melvorD:GP', 'quantity': 1000},
+        ],
+      };
+
+      final action = SummoningAction.fromJson(json, namespace: 'melvorF');
+
+      expect(action.currencyCosts.gpCost, 1000);
+      expect(action.currencyCosts.costs, hasLength(1));
+      expect(action.currencyCosts.costs.first.currency, Currency.gp);
+    });
+
+    test('currencyCosts defaults to empty when absent', () {
+      final json = {
+        'id': 'TestFamiliar',
+        'level': 1,
+        'productID': 'melvorF:Test_Familiar',
+        'baseQuantity': 25,
+        'baseExperience': 5,
+        'itemCosts': [
+          {'id': 'melvorF:Summoning_Shard_Green', 'quantity': 6},
+        ],
+        'nonShardItemCosts': ['melvorD:Normal_Logs'],
+        'tier': 1,
+        'skillIDs': ['melvorD:Woodcutting'],
+      };
+
+      final action = SummoningAction.fromJson(json, namespace: 'melvorF');
+
+      expect(action.currencyCosts.isEmpty, isTrue);
+    });
   });
 
   group('markLevelForCount', () {
@@ -427,6 +472,76 @@ void main() {
         expect(state.canStartAction(summoningAction), isFalse);
       },
     );
+
+    test('canStartAction returns false when missing required currency', () {
+      // Find a familiar with a currency cost (e.g. Leprechaun costs 1000 GP).
+      final pricedAction = testRegistries.summoning.actions.firstWhere(
+        (a) => a.currencyCosts.gpCost > 0,
+      );
+
+      final summoningState = const SummoningState.empty().withMarks(
+        pricedAction.productId,
+        1,
+      );
+
+      // Stock all required input items but provide no GP.
+      var inventory = Inventory.empty(testItems);
+      for (final input in pricedAction.inputs.entries) {
+        final item = testItems.byId(input.key);
+        inventory = inventory.adding(ItemStack(item, count: input.value * 10));
+      }
+
+      final broke = GlobalState.test(
+        testRegistries,
+        summoning: summoningState,
+        inventory: inventory,
+      );
+      expect(broke.canStartAction(pricedAction), isFalse);
+
+      final flush = GlobalState.test(
+        testRegistries,
+        summoning: summoningState,
+        inventory: inventory,
+        gp: pricedAction.currencyCosts.gpCost,
+      );
+      expect(flush.canStartAction(pricedAction), isTrue);
+    });
+
+    test('crafting deducts the currency cost', () {
+      final pricedAction = testRegistries.summoning.actions.firstWhere(
+        (a) => a.currencyCosts.gpCost > 0,
+      );
+      final cost = pricedAction.currencyCosts.gpCost;
+
+      final summoningState = const SummoningState.empty().withMarks(
+        pricedAction.productId,
+        1,
+      );
+
+      // Stock plenty of inputs and enough GP for several crafts.
+      var inventory = Inventory.empty(testItems);
+      for (final input in pricedAction.inputs.entries) {
+        final item = testItems.byId(input.key);
+        inventory = inventory.adding(ItemStack(item, count: input.value * 100));
+      }
+
+      final state = GlobalState.test(
+        testRegistries,
+        summoning: summoningState,
+        inventory: inventory,
+        gp: cost * 10,
+      ).startAction(pricedAction, random: Random(42));
+
+      final builder = StateUpdateBuilder(state);
+      // Each tablet takes 5s; consume ~10s worth of ticks => >=1 craft.
+      consumeTicks(builder, 100, random: Random(42));
+      final after = builder.build();
+
+      final crafts = (cost * 10 - after.gp) ~/ cost;
+      expect(crafts, greaterThan(0));
+      // GP should drop by exactly cost * crafts (no partial deductions).
+      expect(after.gp, cost * 10 - cost * crafts);
+    });
   });
 
   group('Tablet Equipment', () {

--- a/ui/lib/src/screens/summoning.dart
+++ b/ui/lib/src/screens/summoning.dart
@@ -633,6 +633,7 @@ class _SummoningActionDisplay extends StatelessWidget {
       showRecycleBadge: true,
       effectText: effectText,
       showInputShopBadge: true,
+      currencyCosts: action.currencyCosts,
       onStart: onStart,
       onInputItemTap: (item) => _onShardTap(context, item),
     );
@@ -960,6 +961,10 @@ class _RecipesDisplay extends StatelessWidget {
                   entry.value,
                 ),
               ],
+              for (final cost in action.currencyCosts.costs) ...[
+                const SizedBox(width: 6),
+                _buildCurrencyCell(state, cost),
+              ],
             ],
           ),
         ),
@@ -975,6 +980,24 @@ class _RecipesDisplay extends StatelessWidget {
               ),
             ),
           ),
+      ],
+    );
+  }
+
+  Widget _buildCurrencyCell(GlobalState state, CurrencyStack cost) {
+    final canAfford = state.currency(cost.currency) >= cost.amount;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        CachedImage(assetPath: cost.currency.assetPath, size: 16),
+        const SizedBox(width: 2),
+        Text(
+          approximateCreditString(cost.amount),
+          style: TextStyle(
+            fontSize: 12,
+            color: canAfford ? null : Style.errorColor,
+          ),
+        ),
       ],
     );
   }

--- a/ui/lib/src/widgets/production_action_display.dart
+++ b/ui/lib/src/widgets/production_action_display.dart
@@ -4,6 +4,7 @@ import 'package:ui/src/logic/redux_actions.dart';
 import 'package:ui/src/widgets/action_grid.dart';
 import 'package:ui/src/widgets/cached_image.dart';
 import 'package:ui/src/widgets/context_extensions.dart';
+import 'package:ui/src/widgets/cost_row.dart';
 import 'package:ui/src/widgets/count_badge_cell.dart';
 import 'package:ui/src/widgets/double_chance_badge_cell.dart';
 import 'package:ui/src/widgets/duration_badge_cell.dart';
@@ -40,6 +41,7 @@ class ProductionActionDisplay extends StatelessWidget {
     this.effectText,
     this.showInputShopBadge = false,
     this.onInputItemTap,
+    this.currencyCosts = CurrencyCosts.empty,
     super.key,
   });
 
@@ -61,6 +63,10 @@ class ProductionActionDisplay extends StatelessWidget {
   /// Optional callback when an input item is tapped
   /// (e.g., for purchase dialog).
   final void Function(Item item)? onInputItemTap;
+
+  /// Currency costs (e.g. GP) charged each time the action completes.
+  /// Rendered as an additional "Cost:" row below "Requires:" when non-empty.
+  final CurrencyCosts currencyCosts;
 
   bool get _isUnlocked =>
       skillLevel == null || skillLevel! >= action.unlockLevel;
@@ -156,6 +162,11 @@ class ProductionActionDisplay extends StatelessWidget {
           // Row 4: Requires | You Have
           _buildRequiresHaveRow(context, inputs),
           const SizedBox(height: 12),
+
+          if (currencyCosts.isNotEmpty) ...[
+            _buildCostRow(state),
+            const SizedBox(height: 12),
+          ],
 
           // Row 5: Produces | Grants
           _buildProducesGrantsRow(context, outputs),
@@ -299,6 +310,28 @@ class ProductionActionDisplay extends StatelessWidget {
                   onItemTap: onInputItemTap,
                 ),
             ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCostRow(GlobalState state) {
+    final canAffordCosts = {
+      for (final cost in currencyCosts.costs)
+        cost.currency: state.currency(cost.currency) >= cost.amount,
+    };
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Cost: ', style: TextStyle(fontWeight: FontWeight.bold)),
+        Expanded(
+          child: CostRow(
+            currencyCosts: [
+              for (final cost in currencyCosts.costs)
+                (cost.currency, cost.amount),
+            ],
+            canAffordCosts: canAffordCosts,
           ),
         ),
       ],


### PR DESCRIPTION
## Summary
- Recipes like Leprechaun (1000 GP) and Cyclops (1000 SC) declare `currencyCosts` in Melvor data, but `SummoningAction.fromJson` was dropping the field — so the cost was never shown, gated on, or deducted
- Parse the field into the existing `CurrencyCosts` type (reused from the agility / item-upgrade paths), gate `canStartAction` on affordability, and deduct on each craft via `_completeGenericSkillAction`. Charged regardless of preservation
- Tablets UI now renders a "Cost:" row under "Requires:" via `CostRow` (with affordability coloring), and the action list shows an inline currency badge next to the input shards

## Test plan
- [x] `dart test -r failures-only` (logic) — 2385 pass
- [x] `flutter test -r failures-only` (ui) — 175 pass
- [x] New tests: JSON parsing for present + absent currencyCosts, `canStartAction` gating on GP, tick-driven check that GP drops by exactly `cost × crafts`
- [x] `dart format .` and `npx cspell` clean