### PR TITLE
feat: consume potion and miscellaneous modifiers

### DIFF
--- a/logic/lib/src/consume_ticks.dart
+++ b/logic/lib/src/consume_ticks.dart
@@ -1681,23 +1681,28 @@ ForegroundResult _restartOrStop(
       conditionContext: ConditionContext.empty,
     );
     final hasAutoLooting = combatModifiers.autoLooting > 0;
+    final hasAutoBurying = combatModifiers.autoBurying > 0;
+    final allowStacking = combatModifiers.allowLootContainerStacking > 0;
 
     // Drop bones if the monster has them (bones stack in loot).
     // In dungeons, bones only drop when the dungeon's dropBones flag is true.
+    // When autoBurying is active, bones are consumed automatically instead
+    // of being added to loot (prayer XP requires bone XP data).
     final bones = action.bones;
-    if (bones != null && (dungeon?.dropBones ?? true)) {
+    if (bones != null && (dungeon?.dropBones ?? true) && !hasAutoBurying) {
       final item = builder.registries.items.byId(bones.itemId);
       final stack = ItemStack(item, count: bones.quantity);
       if (hasAutoLooting) {
         if (!builder.tryAddToInventory(stack)) {
-          builder.addToLoot(stack, isBones: true);
+          builder.addToLoot(stack, isBones: true, allowStacking: allowStacking);
         }
       } else {
-        builder.addToLoot(stack, isBones: true);
+        builder.addToLoot(stack, isBones: true, allowStacking: allowStacking);
       }
     }
 
-    // Roll loot table if present (regular loot does NOT stack).
+    // Roll loot table if present.
+    // When allowLootContainerStacking is active, loot items stack.
     // Dungeon monsters never drop their personal loot tables.
     if (!isDungeon) {
       final lootTable = action.lootTable;
@@ -1706,10 +1711,18 @@ ForegroundResult _restartOrStop(
         if (loot != null) {
           if (hasAutoLooting) {
             if (!builder.tryAddToInventory(loot)) {
-              builder.addToLoot(loot, isBones: false);
+              builder.addToLoot(
+                loot,
+                isBones: false,
+                allowStacking: allowStacking,
+              );
             }
           } else {
-            builder.addToLoot(loot, isBones: false);
+            builder.addToLoot(
+              loot,
+              isBones: false,
+              allowStacking: allowStacking,
+            );
           }
         }
       }

--- a/logic/lib/src/state.dart
+++ b/logic/lib/src/state.dart
@@ -4201,6 +4201,15 @@ class GlobalState {
     );
   }
 
+  /// Returns the effective charges per potion bottle, including the
+  /// flatPotionCharges modifier bonus.
+  int _effectiveChargesPerPotion(Item potion) {
+    final modifiers = createGlobalModifierProvider(
+      conditionContext: ConditionContext.empty,
+    );
+    return (potion.potionCharges ?? 1) + modifiers.flatPotionCharges;
+  }
+
   /// Returns the remaining charges on the current potion bottle for a skill.
   /// This counts down from [Item.potionCharges] (e.g. 10 → 0), not total uses.
   int currentPotionChargesRemaining(MelvorId skillId) {
@@ -4208,7 +4217,7 @@ class GlobalState {
     if (potionId == null) return 0;
 
     final potion = registries.items.byId(potionId);
-    final chargesPerPotion = potion.potionCharges ?? 1;
+    final chargesPerPotion = _effectiveChargesPerPotion(potion);
     final chargesUsed = potionChargesUsedForSkill(skillId);
     return chargesPerPotion - chargesUsed;
   }
@@ -4220,7 +4229,7 @@ class GlobalState {
     if (potionId == null) return 0;
 
     final potion = registries.items.byId(potionId);
-    final chargesPerPotion = potion.potionCharges ?? 1;
+    final chargesPerPotion = _effectiveChargesPerPotion(potion);
     final chargesUsed = potionChargesUsedForSkill(skillId);
     final chargesLeft = chargesPerPotion - chargesUsed;
     final inventoryCount = inventory.countById(potionId);

--- a/logic/lib/src/state_update_builder.dart
+++ b/logic/lib/src/state_update_builder.dart
@@ -221,8 +221,18 @@ class StateUpdateBuilder {
 
   /// Adds an item to the loot container.
   /// Items lost due to overflow are tracked in Changes.
-  void addToLoot(ItemStack stack, {required bool isBones}) {
-    final (newLoot, lostItems) = _state.loot.addItem(stack, isBones: isBones);
+  /// When [allowStacking] is true (from allowLootContainerStacking modifier),
+  /// all items stack with existing items of the same type.
+  void addToLoot(
+    ItemStack stack, {
+    required bool isBones,
+    bool allowStacking = false,
+  }) {
+    final (newLoot, lostItems) = _state.loot.addItem(
+      stack,
+      isBones: isBones,
+      allowStacking: allowStacking,
+    );
     _state = _state.copyWith(loot: newLoot);
 
     // Track any lost items due to overflow
@@ -455,8 +465,36 @@ class StateUpdateBuilder {
 
   /// Applies the death penalty: randomly selects an equipment slot and
   /// removes any item in it. Tracks the lost item and death in changes.
+  ///
+  /// Modifiers that affect the death penalty:
+  /// - `rebirthChance`: percentage chance to avoid death entirely (no penalty)
+  /// - `itemProtection`: when > 0, equipment is protected from loss on death
+  ///
   /// Returns the result indicating what was lost (if anything).
   DeathPenaltyResult applyDeathPenalty(Random random) {
+    final modifiers = _state.createCombatModifierProvider(
+      conditionContext: ConditionContext.empty,
+    );
+
+    // Check rebirth chance - player avoids death entirely.
+    final rebirthPct = modifiers.rebirthChance;
+    if (rebirthPct > 0 && random.nextDouble() * 100 < rebirthPct) {
+      // Reborn! No death penalty, no item loss. Record death but not loss.
+      _changes = _changes.recordingDeath();
+      final noLossResult = DeathPenaltyResult(equipment: _state.equipment);
+      _lastDeathPenalty = noLossResult;
+      return noLossResult;
+    }
+
+    // Check item protection - equipment is protected from loss.
+    final hasItemProtection = modifiers.itemProtection > 0;
+    if (hasItemProtection) {
+      _changes = _changes.recordingDeath();
+      final protectedResult = DeathPenaltyResult(equipment: _state.equipment);
+      _lastDeathPenalty = protectedResult;
+      return protectedResult;
+    }
+
     final result = _state.equipment.applyDeathPenalty(random);
     _state = _state.copyWith(equipment: result.equipment);
     _lastDeathPenalty = result;
@@ -584,6 +622,7 @@ class StateUpdateBuilder {
     final efficiency = modifiers.autoEatEfficiency;
 
     final canAutoSwap = modifiers.autoSwapFoodUnlocked > 0;
+    final canAutoEquip = modifiers.autoEquipFoodUnlocked > 0;
 
     var foodConsumed = 0;
     var hp = currentHp;
@@ -601,6 +640,11 @@ class StateUpdateBuilder {
           );
           food = _state.equipment.selectedFood;
         }
+      }
+
+      // If still no food and autoEquipFood is unlocked, pull from bank.
+      if (food == null && canAutoEquip) {
+        food = _tryAutoEquipFoodFromBank();
       }
 
       if (food == null) break;
@@ -635,6 +679,27 @@ class StateUpdateBuilder {
     }
 
     return foodConsumed;
+  }
+
+  /// Tries to auto-equip food from the bank into the current food slot.
+  /// Returns the equipped food stack if successful, or null.
+  ItemStack? _tryAutoEquipFoodFromBank() {
+    // Find the best food in inventory (highest heal value).
+    ItemStack? bestFood;
+    for (final stack in _state.inventory.items) {
+      final heals = stack.item.healsFor;
+      if (heals == null || heals <= 0) continue;
+      if (bestFood == null || heals > (bestFood.item.healsFor ?? 0)) {
+        bestFood = stack;
+      }
+    }
+    if (bestFood == null) return null;
+
+    // Move the entire stack from inventory to the current food slot.
+    final newInventory = _state.inventory.removing(bestFood);
+    final newEquipment = _state.equipment.equipFood(bestFood);
+    _state = _state.copyWith(inventory: newInventory, equipment: newEquipment);
+    return _state.equipment.selectedFood;
   }
 
   /// Adds a summoning mark for a familiar.
@@ -896,14 +961,15 @@ class StateUpdateBuilder {
     if (potionId == null) return;
 
     final potion = registries.items.byId(potionId);
-    final maxCharges = potion.potionCharges ?? 1;
 
-    // Check charge preservation chance
+    // Check charge preservation chance and flatPotionCharges bonus
     final modifiers = _state.createActionModifierProvider(
       action,
       conditionContext: ConditionContext.empty, // Skill action, no combat.
       consumesOnType: null,
     );
+    final baseCharges = potion.potionCharges ?? 1;
+    final maxCharges = baseCharges + modifiers.flatPotionCharges;
     final preserveChance = modifiers.potionChargePreservationChance;
     if (preserveChance > 0 && random.nextDouble() * 100 < preserveChance) {
       return; // Charge preserved, don't consume

--- a/logic/lib/src/types/equipment.dart
+++ b/logic/lib/src/types/equipment.dart
@@ -15,17 +15,18 @@ const int foodSlotCount = 3;
 class DeathPenaltyResult {
   const DeathPenaltyResult({
     required this.equipment,
-    required this.slotRolled,
+    this.slotRolled,
     this.itemLost,
   });
 
   /// The updated equipment after the death penalty.
   final Equipment equipment;
 
-  /// The slot that was randomly selected.
-  final EquipmentSlot slotRolled;
+  /// The slot that was randomly selected, or null if no penalty was applied
+  /// (e.g. due to rebirthChance or itemProtection modifiers).
+  final EquipmentSlot? slotRolled;
 
-  /// The item stack that was lost, or null if the slot was empty.
+  /// The item stack that was lost, or null if the slot was empty or protected.
   final ItemStack? itemLost;
 
   /// True if the player was lucky and lost nothing.

--- a/logic/lib/src/types/loot_state.dart
+++ b/logic/lib/src/types/loot_state.dart
@@ -44,17 +44,19 @@ class LootState {
   bool get isFull => stacks.length >= maxLootStacks;
   int get stackCount => stacks.length;
 
-  /// Adds an item to loot. Bones stack; other items create new stacks.
+  /// Adds an item to loot. Bones always stack; other items stack only when
+  /// [allowStacking] is true (from the allowLootContainerStacking modifier).
   /// Returns (newState, lostItems) where lostItems are items that couldn't fit.
   (LootState, List<ItemStack>) addItem(
     ItemStack stack, {
     required bool isBones,
+    bool allowStacking = false,
   }) {
     final newStacks = List<ItemStack>.from(stacks);
     final lostItems = <ItemStack>[];
 
-    if (isBones) {
-      // Bones stack with existing bones of same type
+    if (isBones || allowStacking) {
+      // Stack with existing items of same type
       final existingIndex = newStacks.indexWhere(
         (s) => s.item.id == stack.item.id,
       );
@@ -67,7 +69,7 @@ class LootState {
       }
     }
 
-    // Non-bones or new bones type - add as new stack
+    // Non-stacking or new item type - add as new stack
     if (newStacks.length >= maxLootStacks) {
       // FIFO: remove oldest (first) item
       lostItems.add(newStacks.removeAt(0));

--- a/logic/test/misc_modifier_test.dart
+++ b/logic/test/misc_modifier_test.dart
@@ -1,0 +1,253 @@
+import 'dart:math';
+
+import 'package:logic/logic.dart';
+import 'package:test/test.dart';
+
+import 'test_helper.dart';
+
+void main() {
+  late Item birdNestPotionI;
+  late Item bones;
+  late Item rawChicken;
+  late Item feathers;
+  late Item shrimp;
+  late Action normalTree;
+
+  setUpAll(() async {
+    await loadTestRegistries();
+    birdNestPotionI = testItems.byName('Bird Nest Potion I');
+    bones = testItems.byName('Bones');
+    rawChicken = testItems.byName('Raw Chicken');
+    feathers = testItems.byName('Feathers');
+    shrimp = testItems.byName('Shrimp');
+    normalTree = testRegistries.woodcuttingAction('Normal Tree');
+  });
+
+  group('flatPotionCharges modifier', () {
+    test('consumePotionCharge uses base charges without modifier', () {
+      final charges = birdNestPotionI.potionCharges!;
+      final state = GlobalState.test(
+        testRegistries,
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(birdNestPotionI, count: 2),
+        ]),
+        selectedPotions: {Skill.woodcutting.id: birdNestPotionI.id},
+        potionChargesUsed: {Skill.woodcutting.id: charges - 1},
+      );
+
+      // Use a fixed seed random that won't trigger preservation
+      final random = Random(42);
+      final builder = StateUpdateBuilder(state)
+        ..consumePotionCharge(normalTree as SkillAction, random);
+      final newState = builder.build();
+
+      // At charges-1, consuming one more should reach maxCharges
+      // (base). Since flatPotionCharges modifier is 0 by default,
+      // this should consume one potion from inventory.
+      expect(newState.inventory.countOfItem(birdNestPotionI), 1);
+    });
+  });
+
+  group('allowLootContainerStacking modifier', () {
+    test('non-bone items do not stack without modifier', () {
+      const loot = LootState.empty();
+      final stack1 = ItemStack(rawChicken, count: 1);
+      final stack2 = ItemStack(rawChicken, count: 1);
+
+      final (loot1, _) = loot.addItem(stack1, isBones: false);
+      final (loot2, _) = loot1.addItem(stack2, isBones: false);
+
+      // Without stacking, two separate stacks
+      expect(loot2.stackCount, 2);
+    });
+
+    test('non-bone items stack with allowStacking', () {
+      const loot = LootState.empty();
+      final stack1 = ItemStack(rawChicken, count: 1);
+      final stack2 = ItemStack(rawChicken, count: 1);
+
+      final (loot1, _) = loot.addItem(
+        stack1,
+        isBones: false,
+        allowStacking: true,
+      );
+      final (loot2, _) = loot1.addItem(
+        stack2,
+        isBones: false,
+        allowStacking: true,
+      );
+
+      // With stacking, items combine into one stack
+      expect(loot2.stackCount, 1);
+      expect(loot2.stacks[0].count, 2);
+    });
+
+    test('bones always stack regardless of allowStacking', () {
+      const loot = LootState.empty();
+      final stack1 = ItemStack(bones, count: 1);
+      final stack2 = ItemStack(bones, count: 2);
+
+      final (loot1, _) = loot.addItem(stack1, isBones: true);
+      final (loot2, _) = loot1.addItem(stack2, isBones: true);
+
+      expect(loot2.stackCount, 1);
+      expect(loot2.stacks[0].count, 3);
+    });
+
+    test('different items do not stack with allowStacking', () {
+      const loot = LootState.empty();
+      final stack1 = ItemStack(rawChicken, count: 1);
+      final stack2 = ItemStack(feathers, count: 1);
+
+      final (loot1, _) = loot.addItem(
+        stack1,
+        isBones: false,
+        allowStacking: true,
+      );
+      final (loot2, _) = loot1.addItem(
+        stack2,
+        isBones: false,
+        allowStacking: true,
+      );
+
+      expect(loot2.stackCount, 2);
+    });
+  });
+
+  group('rebirthChance modifier', () {
+    test('death without rebirth always rolls a slot', () {
+      final weapon = testItems.byName('Bronze Scimitar');
+      final equipment = const Equipment.empty().copyWith(
+        gearSlots: {EquipmentSlot.weapon: weapon},
+      );
+      final state = GlobalState.test(testRegistries, equipment: equipment);
+
+      // Without rebirth modifier, all deaths should roll a slot
+      var slotRolledCount = 0;
+      for (var i = 0; i < 50; i++) {
+        final random = Random(i);
+        final builder = StateUpdateBuilder(state)..applyDeathPenalty(random);
+        if (builder.lastDeathPenalty!.slotRolled != null) {
+          slotRolledCount++;
+        }
+      }
+      expect(slotRolledCount, 50);
+    });
+  });
+
+  group('itemProtection modifier', () {
+    test('death without protection can lose items', () {
+      final weapon = testItems.byName('Bronze Scimitar');
+      final equipment = const Equipment.empty().copyWith(
+        gearSlots: {EquipmentSlot.weapon: weapon},
+      );
+      final state = GlobalState.test(testRegistries, equipment: equipment);
+
+      // Run multiple deaths and check that some lose items
+      var lostCount = 0;
+      for (var i = 0; i < 100; i++) {
+        final random = Random(i);
+        final builder = StateUpdateBuilder(state)..applyDeathPenalty(random);
+        if (builder.lastDeathPenalty!.itemLost != null) {
+          lostCount++;
+        }
+      }
+      expect(lostCount, greaterThan(0));
+    });
+  });
+
+  group('DeathPenaltyResult', () {
+    test('slotRolled is nullable for protected deaths', () {
+      const result = DeathPenaltyResult(equipment: Equipment.empty());
+      expect(result.slotRolled, isNull);
+      expect(result.itemLost, isNull);
+      expect(result.wasLucky, isTrue);
+    });
+
+    test('slotRolled is set for normal deaths', () {
+      const result = DeathPenaltyResult(
+        equipment: Equipment.empty(),
+        slotRolled: EquipmentSlot.weapon,
+      );
+      expect(result.slotRolled, EquipmentSlot.weapon);
+      expect(result.wasLucky, isTrue); // No item lost
+    });
+  });
+
+  group('autoEquipFoodUnlocked modifier', () {
+    test('auto-equip food from bank when food slot empty', () {
+      // Create state with food in inventory but not equipped
+      final state = GlobalState.test(
+        testRegistries,
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(shrimp, count: 10),
+        ]),
+        health: const HealthState(lostHp: 50),
+      );
+
+      // With autoEquipFoodUnlocked and autoEatThreshold
+      final modifiers = StubModifierProvider({
+        'autoEatThreshold': 80,
+        'autoEatHPLimit': 100,
+        'autoEatEfficiency': 100,
+        'autoEquipFoodUnlocked': 1,
+      });
+
+      final builder = StateUpdateBuilder(state);
+      final consumed = builder.tryAutoEat(modifiers);
+
+      // Should have auto-equipped and eaten food
+      expect(consumed, greaterThan(0));
+    });
+
+    test('no auto-equip without modifier', () {
+      final state = GlobalState.test(
+        testRegistries,
+        inventory: Inventory.fromItems(testItems, [
+          ItemStack(shrimp, count: 10),
+        ]),
+        health: const HealthState(lostHp: 50),
+      );
+
+      // Without autoEquipFoodUnlocked
+      final modifiers = StubModifierProvider({
+        'autoEatThreshold': 80,
+        'autoEatHPLimit': 100,
+        'autoEatEfficiency': 100,
+      });
+
+      final builder = StateUpdateBuilder(state);
+      final consumed = builder.tryAutoEat(modifiers);
+
+      // No food equipped, should not eat
+      expect(consumed, 0);
+    });
+  });
+
+  group('StateUpdateBuilder.addToLoot with allowStacking', () {
+    test('passes allowStacking to LootState.addItem', () {
+      final state = GlobalState.test(testRegistries);
+      // Add same item twice without stacking
+      final builder = StateUpdateBuilder(state)
+        ..addToLoot(ItemStack(rawChicken, count: 1), isBones: false)
+        ..addToLoot(ItemStack(rawChicken, count: 1), isBones: false);
+      expect(builder.state.loot.stackCount, 2);
+
+      // Reset and add with stacking
+      final state2 = GlobalState.test(testRegistries);
+      final builder2 = StateUpdateBuilder(state2)
+        ..addToLoot(
+          ItemStack(rawChicken, count: 1),
+          isBones: false,
+          allowStacking: true,
+        )
+        ..addToLoot(
+          ItemStack(rawChicken, count: 1),
+          isBones: false,
+          allowStacking: true,
+        );
+      expect(builder2.state.loot.stackCount, 1);
+      expect(builder2.state.loot.stacks[0].count, 2);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Consume potion and miscellaneous modifiers.

Recovered from an orphan agent worktree during cleanup. Opening as draft — verify the change still applies before marking ready.